### PR TITLE
🐛✅ make sure we send correct local static file path

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "npm run lint && npm run test:integration && npm run coverage",
     "test:unit": "tape test/unit/*-test.js test/unit/**/*-test.js test/unit/**/**/*-test.js | tap-spec",
     "test:integration": "tape test/integration/*-test.js | tap-spec",
-    "coverage": "nyc --reporter=lcov --reporter=text-summary npm run test:unit",
+    "coverage": "nyc --reporter=lcov --reporter=text npm run test:unit",
     "lint": "eslint src --fix"
   },
   "repository": {

--- a/src/http/public-middleware.js
+++ b/src/http/public-middleware.js
@@ -25,7 +25,7 @@ function sends(req, res, next) {
 
   let root = process.env.ARC_SANDBOX_PATH_TO_STATIC
   let pathToFile = url.parse(basePath).pathname
-  let fullPath = path.join(process.cwd(), root, decodeURI(pathToFile))
+  let fullPath = path.join(root, decodeURI(pathToFile))
 
   let found = exists(fullPath) && fs.statSync(fullPath).isFile()
   if (!found) {

--- a/test/unit/src/http/public-middleware-test.js
+++ b/test/unit/src/http/public-middleware-test.js
@@ -1,0 +1,58 @@
+let test = require('tape')
+let fs = require('fs')
+let path = require('path')
+let sinon = require('sinon')
+let proxyquire = require('proxyquire')
+let sendStub = sinon.stub().returns({
+  on: sinon.stub().returnsThis(),
+  pipe: sinon.stub().returns(true)
+})
+let existsStub = sinon.stub(fs, 'existsSync').returns(true)
+let pub = proxyquire('../../../../src/http/public-middleware', {
+  'send': sendStub
+})
+let origEnv = process.env.ARC_SANDBOX_PATH_TO_STATIC
+let origCwd = process.cwd()
+let mock = path.join(__dirname, '..', '..', '..', 'mock', 'normal')
+
+test('public-middleware test setup', t=>{
+  t.plan(1)
+  process.chdir(mock)
+  process.env.ARC_SANDBOX_PATH_TO_STATIC = path.join(mock, 'public')
+  t.equals(process.cwd(), mock)
+})
+
+test('public-middleware should invoke next() if url does not start with _static', t => {
+  t.plan(1)
+  let fake = sinon.fake()
+  pub({url:'/api/signup'}, null, fake)
+  t.ok(fake.calledOnce, 'next() invoked')
+})
+
+test('public-middleware should invoke next() if url starts with _static but does not exist', t => {
+  t.plan(1)
+  existsStub.returns(false)
+  let fake = sinon.fake()
+  pub({url:'/_static/my.css'}, null, fake)
+  t.ok(fake.calledOnce, 'next() invoked')
+})
+test('public-middleware should invoke send() with file location if url starts with _static and exists', t => {
+  t.plan(2)
+  existsStub.returns(true)
+  existsStub.resetHistory()
+  let statStub = sinon.stub(fs, 'statSync').returns({ isFile: sinon.fake.returns(true) })
+  let req = {url:'/_static/my.css'}
+  let correct = path.join(mock, 'public', 'my.css')
+  pub(req, null, sinon.fake())
+  t.equals(existsStub.lastCall.args[0], correct, 'correct file checked for existence')
+  t.equals(statStub.lastCall.args[0], correct, 'correct file stated')
+  existsStub.restore()
+  statStub.restore()
+})
+
+test('public-middleware test teardown', t=>{
+  t.plan(1)
+  process.chdir(origCwd)
+  process.env.ARC_SANDBOX_PATH_TO_STATIC = origEnv
+  t.equals(process.cwd(), origCwd)
+})


### PR DESCRIPTION
… when serving static assets. also adds tests for public middleware.

this fixes #25.