### PR TITLE
Fixes issue where Arc 6 non-GET verbs with bodies were stalling sandbox

### DIFF
--- a/src/http/index.js
+++ b/src/http/index.js
@@ -17,6 +17,7 @@ let fallback = require('./fallback')
 
 // config arcana
 let jsonTypes = /^application\/.*json/
+let formURLenc = 'application/x-www-form-urlencoded'
 let limit = '6mb';
 let app = Router({mergeParams: true})
 
@@ -31,6 +32,8 @@ app.use(body.json({
 app.use(body.urlencoded({
   extended: false,
   limit,
+  type: req => req.headers['content-type'].includes(formURLenc) &&
+               !req.isBase64Encoded
 }))
 
 app.use(publicMiddleware)

--- a/test/integration/http-test.js
+++ b/test/integration/http-test.js
@@ -4,6 +4,8 @@ let test = require('tape')
 let sandbox = require('../../src')
 let {http} = require('../../src')
 
+let b64dec = i => Buffer.from(i, 'base64').toString()
+
 let client
 test('env', t=> {
   t.plan(2)
@@ -111,7 +113,79 @@ test('get /ruby2.5', t=> {
   })
 })
 
-// TODO possibly some POST/PUT/PATCH/DELETE tests?
+test('post /post', t=> {
+  t.plan(3)
+  let data = {hi: 'there'}
+  tiny.post({
+    url: 'http://localhost:3333/post',
+    data,
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+  }, function _got(err, result) {
+    if (err) t.fail(err)
+    else {
+      t.ok(true, 'posted /post')
+      t.equal(b64dec(result.body.body), 'hi=there', 'Got base64-encoded form URL-encoded body payload')
+      t.ok(result.body.isBase64Encoded, 'Got isBase64Encoded flag')
+      console.log(result.body)
+    }
+  })
+})
+
+test('put /put', t=> {
+  t.plan(3)
+  let data = {hi: 'there'}
+  tiny.put({
+    url: 'http://localhost:3333/put',
+    data,
+  }, function _got(err, result) {
+    if (err) t.fail(err)
+    else {
+      t.ok(true, 'put /put')
+      t.equal(b64dec(result.body.body), JSON.stringify(data), 'Got base64-encoded JSON-encoded body payload')
+      t.ok(result.body.isBase64Encoded, 'Got isBase64Encoded flag')
+      console.log(result.body)
+    }
+  })
+})
+
+/**
+ * Uncomment this when tiny supports patch :)
+ */
+/*
+test('patch /patch', t=> {
+  t.plan(3)
+  let data = {hi: 'there'}
+  tiny.patch({
+    url: 'http://localhost:3333/patch',
+    data,
+  }, function _got(err, result) {
+    if (err) t.fail(err)
+    else {
+      t.ok(true, 'patched /patch')
+      t.equal(b64dec(result.body.body), JSON.stringify(data), 'Got base64-encoded JSON-encoded body payload')
+      t.ok(result.body.isBase64Encoded, 'Got isBase64Encoded flag')
+      console.log(result.body)
+    }
+  })
+})
+*/
+
+test('delete /delete', t=> {
+  t.plan(3)
+  let data = {hi: 'there'}
+  tiny.del({
+    url: 'http://localhost:3333/delete',
+    data,
+  }, function _got(err, result) {
+    if (err) t.fail(err)
+    else {
+      t.ok(true, 'deleted /delete')
+      t.equal(b64dec(result.body.body), JSON.stringify(data), 'Got base64-encoded JSON-encoded body payload')
+      t.ok(result.body.isBase64Encoded, 'Got isBase64Encoded flag')
+      console.log(result.body)
+    }
+  })
+})
 
 test('http.close', t=> {
   t.plan(1)
@@ -258,6 +332,84 @@ test('get /binary', t=> {
       t.ok(true, 'got /binary')
       t.ok(img.startsWith('AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAA'), 'is binary')
       console.log({data})
+    }
+  })
+})
+
+test('post /post', t=> {
+  t.plan(3)
+  let data = {hi: 'there'}
+  tiny.post({
+    url: 'http://localhost:3333/post',
+    data,
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+  }, function _got(err, result) {
+    if (err) t.fail(err)
+    else {
+      t.ok(true, 'posted /post')
+      t.equal(JSON.stringify(result.body.body), JSON.stringify(data), 'Got base64-encoded form URL-encoded body payload')
+      t.notOk(result.body.isBase64Encoded, 'No isBase64Encoded flag')
+      console.log(result.body)
+      t.end()
+    }
+  })
+})
+
+test('put /put', t=> {
+  t.plan(3)
+  let data = {hi: 'there'}
+  tiny.put({
+    url: 'http://localhost:3333/put',
+    data,
+  }, function _got(err, result) {
+    if (err) t.fail(err)
+    else {
+      t.ok(true, 'put /put')
+      t.equal(JSON.stringify(result.body.body), JSON.stringify(data), 'Got base64-encoded JSON-encoded body payload')
+      t.notOk(result.body.isBase64Encoded, 'No isBase64Encoded flag')
+      console.log(result.body)
+      t.end()
+    }
+  })
+})
+
+/**
+ * Uncomment this when tiny supports patch :)
+ */
+/*
+test('patch /patch', t=> {
+  t.plan(3)
+  let data = {hi: 'there'}
+  tiny.patch({
+    url: 'http://localhost:3333/patch',
+    data,
+  }, function _got(err, result) {
+    if (err) t.fail(err)
+    else {
+      t.ok(true, 'patched /patch')
+      t.equal(JSON.stringify(result.body.body), JSON.stringify(data), 'Got base64-encoded JSON-encoded body payload')
+      t.notOk(result.body.isBase64Encoded, 'No isBase64Encoded flag')
+      console.log(result.body)
+      t.end()
+    }
+  })
+})
+*/
+
+test('delete /delete', t=> {
+  t.plan(3)
+  let data = {hi: 'there'}
+  tiny.del({
+    url: 'http://localhost:3333/delete',
+    data,
+  }, function _got(err, result) {
+    if (err) t.fail(err)
+    else {
+      t.ok(true, 'deleted /delete')
+      t.equal(JSON.stringify(result.body.body), JSON.stringify(data), 'Got base64-encoded JSON-encoded body payload')
+      t.notOk(result.body.isBase64Encoded, 'No isBase64Encoded flag')
+      console.log(result.body)
+      t.end()
     }
   })
 })

--- a/test/mock/normal/.arc
+++ b/test/mock/normal/.arc
@@ -14,6 +14,10 @@ get /nodejs8.10
 get /python3.7
 get /python3.6
 get /ruby2.5
+post /post
+put /put
+patch /patch
+delete /delete
 
 @tables
 accounts

--- a/test/mock/normal/src/http/delete-delete/.arc-config
+++ b/test/mock/normal/src/http/delete-delete/.arc-config
@@ -1,0 +1,5 @@
+@aws
+runtime nodejs10.x
+timeout 10
+# concurrency 1
+# memory 1152

--- a/test/mock/normal/src/http/delete-delete/index.js
+++ b/test/mock/normal/src/http/delete-delete/index.js
@@ -1,0 +1,8 @@
+// Boilerplate Lambda function pulled from AWS
+exports.handler = async (event) => {
+  const response = {
+    statusCode: 200,
+    body: JSON.stringify(event),
+  };
+  return response;
+};

--- a/test/mock/normal/src/http/patch-patch/.arc-config
+++ b/test/mock/normal/src/http/patch-patch/.arc-config
@@ -1,0 +1,5 @@
+@aws
+runtime nodejs10.x
+timeout 10
+# concurrency 1
+# memory 1152

--- a/test/mock/normal/src/http/patch-patch/index.js
+++ b/test/mock/normal/src/http/patch-patch/index.js
@@ -1,0 +1,8 @@
+// Boilerplate Lambda function pulled from AWS
+exports.handler = async (event) => {
+  const response = {
+    statusCode: 200,
+    body: JSON.stringify(event),
+  };
+  return response;
+};

--- a/test/mock/normal/src/http/post-post/.arc-config
+++ b/test/mock/normal/src/http/post-post/.arc-config
@@ -1,0 +1,5 @@
+@aws
+runtime nodejs10.x
+timeout 10
+# concurrency 1
+# memory 1152

--- a/test/mock/normal/src/http/post-post/index.js
+++ b/test/mock/normal/src/http/post-post/index.js
@@ -1,0 +1,8 @@
+// Boilerplate Lambda function pulled from AWS
+exports.handler = async (event) => {
+  const response = {
+    statusCode: 200,
+    body: JSON.stringify(event),
+  };
+  return response;
+};

--- a/test/mock/normal/src/http/put-put/.arc-config
+++ b/test/mock/normal/src/http/put-put/.arc-config
@@ -1,0 +1,5 @@
+@aws
+runtime nodejs10.x
+timeout 10
+# concurrency 1
+# memory 1152

--- a/test/mock/normal/src/http/put-put/index.js
+++ b/test/mock/normal/src/http/put-put/index.js
@@ -1,0 +1,8 @@
+// Boilerplate Lambda function pulled from AWS
+exports.handler = async (event) => {
+  const response = {
+    statusCode: 200,
+    body: JSON.stringify(event),
+  };
+  return response;
+};


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [x] Added and/or updated unit tests (if appropriate)
  - [x] Added and/or updated integration tests (if appropriate)
- [x] Updated relevant documentation:
  - [x] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [x] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [x] Summarized your changes in `changelog.md`
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
