### PR TITLE
Fixes base64 issue with /__arc WS handler

### DIFF
--- a/src/http/register-websocket.js
+++ b/src/http/register-websocket.js
@@ -83,6 +83,10 @@ module.exports = function registerWebSocket({app, server}) {
 
   // create a handler for receiving arc.ws.send messages
   app.post('/__arc', function handle(req, res) {
+    if (req.isBase64Encoded) {
+      let buffer = new Buffer(req.body, 'base64')
+      req.body = JSON.parse(buffer.toString())
+    }
     let client = connections.find(client=> req.body.id === client.id)
     if (client) {
       try {


### PR DESCRIPTION
Something has caused the `@architect/functions` package's `ws.send` function to base64 encode the body of a request to the internal sandbox WS handler, which caused that function to not work as expected.

This is a slightly hacky solution which fixes the issue, but it feels like a better long term solution would be to work out why and stop the `ws.send` function from base64 encoding the body in the first place, as the JSON decoding inside this function duplicates the middleware that already exists for non-encoded body content.