### PR TITLE
Fixes TypeError on function request with body and no `Content-Type` header

### DIFF
--- a/src/http/index.js
+++ b/src/http/index.js
@@ -32,7 +32,7 @@ app.use(body.json({
 app.use(body.urlencoded({
   extended: false,
   limit,
-  type: req => req.headers['content-type'].includes(formURLenc) &&
+  type: req => (req.headers['content-type'] || []).includes(formURLenc) &&
                !req.isBase64Encoded
 }))
 

--- a/src/http/index.js
+++ b/src/http/index.js
@@ -17,7 +17,7 @@ let fallback = require('./fallback')
 
 // config arcana
 let jsonTypes = /^application\/.*json/
-let formURLenc = 'application/x-www-form-urlencoded'
+let formURLenc = /^application\/x-www-form-urlencoded/
 let limit = '6mb';
 let app = Router({mergeParams: true})
 
@@ -32,7 +32,7 @@ app.use(body.json({
 app.use(body.urlencoded({
   extended: false,
   limit,
-  type: req => (req.headers['content-type'] || []).includes(formURLenc) &&
+  type: req => formURLenc.test(req.headers['content-type']) &&
                !req.isBase64Encoded
 }))
 


### PR DESCRIPTION
Because the header may be missing, we shouldn't rely on calling the `Array.includes` function.