### PR TITLE
allow user-middleware

### DIFF
--- a/src/http/index.js
+++ b/src/http/index.js
@@ -72,6 +72,11 @@ app.start = function start(callback) {
         return
       }
     }
+
+    if (module.exports.middleware) {
+      app.use(module.exports.middleware)
+    }
+
     app(req, res, finalhandler(req, res))
   })
 


### PR DESCRIPTION
This just adds a quick check for sandbox middleware. It allows the user to inject their own connect-style middleware. Here is an example that injects parcel's HMR dev-server express middleware into running arc app:

```js
import Bundler from 'parcel-bundler'
import express from 'express'
import sandbox from '@architect/sandbox'

const app = express()
const bundler = new Bundler(`${__dirname}/frontend/index.html`)
app.use(bundler.middleware())

// this is the key part
sandbox.http.middleware = app

sandbox.start()
```

Multiple user middlewares can be injected by adding more `app.use` calls, in user-code.

Otherwise, sandbox works the same, listens on same port, outputs same stuff, etc.
