### PR TITLE
Create package.json is missing for lambda

### DIFF
--- a/src/invoke-lambda/warn.js
+++ b/src/invoke-lambda/warn.js
@@ -17,7 +17,7 @@ module.exports = function warn (missing=[], pathToLambda) {
       pathToLambda = pathToLambda.replace(process.cwd(), '').substr(1)
 
       update.warn(`Your function may have ${plural ? 'dependencies' : 'a dependency'} that could be inaccessible in production`)
-      missing = missing.map(dep => `Please run: cd ${pathToLambda} && npm i ${dep}`)
+      missing = missing.map(dep => `Please run: cd ${pathToLambda} && [ -f package.json ] || npm init -y && npm i ${dep}`)
       update.status(null, ...missing)
     }
   }


### PR DESCRIPTION
If we don't make sure there's a package.json file within the lambda directory, dependency will be installed in a parent package.json instead.

IMO a better approach might be that the sandbox would create `package.json` inside each lambda, so we don't have to make this check.

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
