### PR TITLE
Adds support for `multiValueHeaders` in response object

### DIFF
--- a/src/http/invoke-http/_res-fmt.js
+++ b/src/http/invoke-http/_res-fmt.js
@@ -13,11 +13,11 @@ module.exports = function responseFormatter ({res, result}) {
                     result && result.multiValueHeaders && result.multiValueHeaders['content-type'] ||
                     result && result.headers && result.headers['Content-Type'] ||
                     result && result.headers && result.headers['content-type']
-  res.setHeader('Content-Type', contentType || 'application/json; charset=utf-8')
-  if (result.multiValueHeaders && result.multiValueHeaders['content-type'])
-    delete result.multiValueHeaders['content-type']
-  if (result.headers && result.headers['content-type'])
-    delete result.headers['content-type']
+  res.setHeader('Content-Type', contentType || 'application/json; charset=utf-8');
+  [result.multiValueHeaders || {}, result.headers || {}].forEach(headers => Object.keys(headers).forEach(key => {
+    if (key.toLowerCase() !== 'content-type') return
+    delete headers[key];
+  }));
 
   // Headers
   let headers = result.multiValueHeaders || result.headers

--- a/src/http/invoke-http/_res-fmt.js
+++ b/src/http/invoke-http/_res-fmt.js
@@ -9,20 +9,31 @@ module.exports = function responseFormatter ({res, result}) {
   // Content type
   // Note: result.headers is a case-sensitive js object,
   //       res.get/setHeader is not (e.g. 'set-cookie' == 'Set-Cookie')
-  let contentType = result && result.headers && result.headers['Content-Type'] ||
+  let contentType = result && result.multiValueHeaders && result.multiValueHeaders['Content-Type'] ||
+                    result && result.multiValueHeaders && result.multiValueHeaders['content-type'] ||
+                    result && result.headers && result.headers['Content-Type'] ||
                     result && result.headers && result.headers['content-type']
   res.setHeader('Content-Type', contentType || 'application/json; charset=utf-8')
-  if (result.headers && result.headers['content-type']) delete result.headers['content-type']
+  if (result.multiValueHeaders && result.multiValueHeaders['content-type'])
+    delete result.multiValueHeaders['content-type']
+  else if (result.headers && result.headers['content-type']) {
+    delete result.headers['content-type']
+  }
 
   // Headers
-  if (result.headers) {
-    Object.keys(result.headers).forEach(k=> {
-      if (k.toLowerCase() === 'set-cookie' && result.headers[k]) {
-        res.setHeader(k, result.headers[k].replace('; Secure', '; Path=/'))
-      } else if (k === 'cache-control' && result.headers[k]) {
-        res.setHeader('Cache-Control', result.headers[k])
+  const headers = result.multiValueHeaders || result.headers
+  if (headers) {
+    Object.keys(headers).forEach(k=> {
+      if (k.toLowerCase() === 'set-cookie' && headers[k]) {
+        if (!Array.isArray(headers[k]))
+          res.setHeader(k, headers[k].replace('; Secure', '; Path=/'))
+        else {
+          res.setHeader(k, headers[k].map(value => value.replace('; Secure', '; Path=/')))
+        }
+      } else if (k === 'cache-control' && headers[k]) {
+        res.setHeader('Cache-Control', headers[k])
       } else {
-        res.setHeader(k, result.headers[k])
+        res.setHeader(k, headers[k])
       }
     })
   }

--- a/src/http/invoke-http/_validator.js
+++ b/src/http/invoke-http/_validator.js
@@ -23,6 +23,7 @@ module.exports = function responseValidator ({res, result}) {
     'statusCode',
     'body',
     'headers',
+    'multiValueHeaders',
     'isBase64Encoded'
   ]
 

--- a/test/unit/src/http/http-res-fixtures.js
+++ b/test/unit/src/http/http-res-fixtures.js
@@ -34,6 +34,11 @@ let arc6 = {
   encodedWithBinaryType: {
     body: b64enc('hi there\n'),
     headers: {'Content-Type': 'application/pdf'}
+  },
+
+  // Set multiValueHeaders
+  multiValueHeaders: {
+    multiValueHeaders: {'Set-Cookie': ['Foo', 'Bar']}
   }
 }
 

--- a/test/unit/src/http/http-res-fixtures.js
+++ b/test/unit/src/http/http-res-fixtures.js
@@ -38,6 +38,7 @@ let arc6 = {
 
   // Set multiValueHeaders
   multiValueHeaders: {
+    headers: {'Set-Cookie': 'Baz'},
     multiValueHeaders: {'Set-Cookie': ['Foo', 'Bar']}
   }
 }

--- a/test/unit/src/http/http-res-fixtures.js
+++ b/test/unit/src/http/http-res-fixtures.js
@@ -38,8 +38,8 @@ let arc6 = {
 
   // Set multiValueHeaders
   multiValueHeaders: {
-    headers: {'Set-Cookie': 'Baz'},
-    multiValueHeaders: {'Set-Cookie': ['Foo', 'Bar']}
+    headers: {'Content-Type': 'text/plain', 'Set-Cookie': 'Baz'},
+    multiValueHeaders: {'Content-Type': ['text/plain'], 'Set-Cookie': ['Foo', 'Bar']}
   }
 }
 

--- a/test/unit/src/http/invoke-http/index-res-test.js
+++ b/test/unit/src/http/invoke-http/index-res-test.js
@@ -41,7 +41,7 @@ let teardown = () => {
 }
 
 test('Architect v6 dependency-free responses', t => {
-  t.plan(11)
+  t.plan(13)
   let run = (response, callback) => {
     let output = {
       getHeader: sinon.fake(getHeader.bind({}, null)),
@@ -70,6 +70,10 @@ test('Architect v6 dependency-free responses', t => {
     t.equal(b64dec(res.body), 'hi there\n', 'Body still base64 encoded')
     t.notOk(res.isBase64Encoded, 'isBase64Encoded param NOT set automatically')
     t.equal(res.statusCode, 200, 'Responded with 200')
+  })
+  run(responses.arc6.multiValueHeaders, res => {
+    t.equal(res.headers['Set-Cookie'][0], 'Foo', 'First header value set')
+    t.equal(res.headers['Set-Cookie'][1], 'Bar', 'Second header value set')
   })
   run(responses.arc5.cookie, res => {
     t.ok(res.body.includes('Invalid response parameter'), 'Arc v5 style parameter causes error')

--- a/test/unit/src/http/invoke-http/index-res-test.js
+++ b/test/unit/src/http/invoke-http/index-res-test.js
@@ -41,7 +41,7 @@ let teardown = () => {
 }
 
 test('Architect v6 dependency-free responses', t => {
-  t.plan(12)
+  t.plan(13)
   let run = (response, callback) => {
     let output = {
       getHeader: sinon.fake(getHeader.bind({}, null)),
@@ -73,6 +73,7 @@ test('Architect v6 dependency-free responses', t => {
   })
   run(responses.arc6.multiValueHeaders, res => {
     t.deepEqual(res.headers['Set-Cookie'], ['Foo', 'Bar', 'Baz'], 'Header values set')
+    t.deepEqual(res.headers['Content-Type'], ['text/plain'], 'Content-Type favors multiValueHeaders')
   })
   run(responses.arc5.cookie, res => {
     t.ok(res.body.includes('Invalid response parameter'), 'Arc v5 style parameter causes error')

--- a/test/unit/src/http/invoke-http/index-res-test.js
+++ b/test/unit/src/http/invoke-http/index-res-test.js
@@ -41,7 +41,7 @@ let teardown = () => {
 }
 
 test('Architect v6 dependency-free responses', t => {
-  t.plan(13)
+  t.plan(12)
   let run = (response, callback) => {
     let output = {
       getHeader: sinon.fake(getHeader.bind({}, null)),
@@ -72,8 +72,7 @@ test('Architect v6 dependency-free responses', t => {
     t.equal(res.statusCode, 200, 'Responded with 200')
   })
   run(responses.arc6.multiValueHeaders, res => {
-    t.equal(res.headers['Set-Cookie'][0], 'Foo', 'First header value set')
-    t.equal(res.headers['Set-Cookie'][1], 'Bar', 'Second header value set')
+    t.deepEqual(res.headers['Set-Cookie'], ['Foo', 'Bar', 'Baz'], 'Header values set')
   })
   run(responses.arc5.cookie, res => {
     t.ok(res.body.includes('Invalid response parameter'), 'Arc v5 style parameter causes error')


### PR DESCRIPTION
Further to https://github.com/architect/architect/issues/764, API Gateway supports `multiValueHeaders` in response.

This commit tweaks the Sandbox response validator to not reject that property in a response object and also for the invocation logic to handle `multiValueHeaders` values in the same way `headers` values are (e.g. cookie/content-type handling).

Node.js HTTP server accepts either single strings or arrays to `setHeader()`, so no further effort was required to map multiple values back to the Sandbox's internal HTTP response.

Tests also updated to cover this additional functionality (and verify no regressions introduced).

Verified that locally Sandbox now returns multiple headers for an example header `Test`:

```
$ http localhost:3333
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 0
Content-Type: application/json; charset=utf-8
Date: Fri, 17 Apr 2020 09:24:52 GMT
Test: Value1
Test: Value2
```

and that deploying the same code to AWS has the same behaviour:

```
$ http https://ru7otvkche.execute-api.us-west-2.amazonaws.com/staging
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 0
Content-Type: application/json
Date: Fri, 17 Apr 2020 09:26:32 GMT
Test: Value1
Test: Value2
X-Amzn-Trace-Id: Root=1-5e997648-4484556eab80abb5ee0fda32;Sampled=0
x-amz-apigw-id: LH9rRG6_PHcFSLQ=
x-amzn-RequestId: cdab7779-626b-497f-9123-32f3ecd708e5
```
