### PR TITLE
Fix port in use error code check

### DIFF
--- a/src/db/_check-port.js
+++ b/src/db/_check-port.js
@@ -2,7 +2,7 @@ let net = require('net')
 module.exports = function checkPort(port, fn) {
   let tester = net.createServer()
   .once('error', function (err) {
-    if (err.code != 'EADDRINUSE') return fn(err)
+    if (err.code == 'EADDRINUSE') return fn(err)
     fn(null, true)
   })
   .once('listening', function() {


### PR DESCRIPTION
`arc sandbox` with `@tables` fails with a cryptic error, if the default 5000 port was already in use. I think we should check for `==` rather than `!=` here.

Steps to reproduce:

```bash
npm init -y
npm i @architect/architect
./node_modules/.bin/arc init
cat >> .arc << EOF

@tables
example
  foo *String
EOF
cat > server.js << EOF
require('http').createServer((req_, res) => {
  res.writeHead(401);
  res.end();
}).listen(5000);
EOF
node server &
./node_modules/.bin/arc sandbox && kill $!
```

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
