### PR TITLE
when cleaning tables attributes, ignore encrypt param

### DIFF
--- a/src/db/create-table/_remove-ttl-and-lambda.js
+++ b/src/db/create-table/_remove-ttl-and-lambda.js
@@ -1,7 +1,7 @@
 module.exports = function _removeTTL (attr) {
   var clean = {}
-  Object.keys(attr).forEach(k => {
-    if (attr[k] != 'TTL' && attr[k] != 'Lambda' && k != 'stream') {
+  Object.keys(attr).forEach(k=> {
+    if (attr[k] != 'TTL' && attr[k] != 'Lambda' && k != 'stream' && k != 'encrypt') {
       clean[k] = attr[k]
     }
   })

--- a/test/unit/src/db/create-table/_remove-ttl-and-lambda-test.js
+++ b/test/unit/src/db/create-table/_remove-ttl-and-lambda-test.js
@@ -1,0 +1,30 @@
+let clean = require('../../../../../src/db/create-table/_remove-ttl-and-lambda')
+let test = require('tape')
+
+test('_remove-ttl-and-lambda should ignore params with a value of TTL', t => {
+  t.plan(2)
+  let cleaned = clean({key:'value',_ttl:'TTL'})
+  t.equals(cleaned.key, 'value', 'did not remove legit value')
+  t.notOk(cleaned._ttl, 'removed TTL param')
+});
+
+test('_remove-ttl-and-lambda should ignore stream param', t => {
+  t.plan(2)
+  let cleaned = clean({key:'value',stream:'yes'})
+  t.equals(cleaned.key, 'value', 'did not remove legit value')
+  t.notOk(cleaned.stream, 'removed stream param')
+});
+
+test('_remove-ttl-and-lambda should ignore params with a value of Lambda', t => {
+  t.plan(2)
+  let cleaned = clean({key:'value',wut:'Lambda'})
+  t.equals(cleaned.key, 'value', 'did not remove legit value')
+  t.notOk(cleaned.Lambda, 'removed Lambda param')
+});
+
+test('_remove-ttl-and-lambda should ignore encrypt param', t => {
+  t.plan(2)
+  let cleaned = clean({key:'value',encrypt:true})
+  t.equals(cleaned.key, 'value', 'did not remove legit value')
+  t.notOk(cleaned.encrypt, 'removed encrypt param')
+});


### PR DESCRIPTION
also added unit tests for the clean module for this.

this should fix https://github.com/architect/architect/issues/785

i think this needs a bit of a review, though, as i think other params are also missing here based on the arc.codes docs, things like:

- unclear if the trigger for TTL is the parameter name (`_ttl`) or value (`TTL`), or both? the docs say you should specify `_ttl TTL` to set TTL on, but the clean method only looks at the value. whatever the result here, the docs could probably use some clarifying language to make this more explicit.
- we should also add PointINTimeRecovery to this list
- maybe we could somehow share the architect/package module for use in sandbox instead of copy/pasting it over, as it seems to contain all the cases? not sure. thoughts? https://github.com/architect/package/blob/master/src/visitors/tables/clean.js

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
