### PR TITLE
Enable the `sandbox` flag when hydrating

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Architect Sandbox changelog
 
+### Change
+
+- Speed up hydration by using symlinks instead of copying, whenever the
+  filesystem supports this.
+
 ---
 
 ## [1.13.0] 2020-07-05

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -73,7 +73,7 @@ module.exports = function cli (params = {}, callback) {
         ts()
         let start = Date.now()
         update.status(msg)
-        hydrate.shared({ only }, () => {
+        hydrate.shared({ only, sandbox: true }, () => {
           let end = Date.now()
           update.done(`Files rehydrated into functions in ${end - start}ms`)
         })

--- a/src/http/maybe-hydrate.js
+++ b/src/http/maybe-hydrate.js
@@ -45,7 +45,7 @@ module.exports = function maybeHydrate (callback) {
           let copyShared = false
           // Disable sidecar shared/views hydration; handled project-wide elsewhere
           let hydrateShared = path === shared || path === views || false
-          hydrate.install({ basepath, copyShared, hydrateShared }, callback)
+          hydrate.install({ basepath, copyShared, hydrateShared, sandbox: true }, callback)
         }
         series([
           function _packageJson (callback) {

--- a/src/sandbox/index.js
+++ b/src/sandbox/index.js
@@ -200,7 +200,7 @@ function start (params, callback) {
      * ... then hydrate Architect project files into functions
      */
     function _hydrateShared (callback) {
-      hydrate({ install: false }, function next (err) {
+      hydrate({ install: false, sandbox: true }, function next (err) {
         if (err) callback(err)
         else {
           if (!quiet) {


### PR DESCRIPTION
This shouldn't break anything if the `sandbox` flag is unsupported, but we should probably bump the `@architect/hydrate` dependency once there's a new `@architect/hydrate` release.

By the way, I couldn't run the test suite locally because I'm getting [this error](https://gist.github.com/joliss/6d561cffa319f6960cb7c7b41e7b2ca6#file-npm-test-L610). Not sure what's going on.

I intentionally didn't add a test for this. I hope that's OK!