### PR TITLE
Make sandbox start even more quiet

### DIFF
--- a/src/sandbox/index.js
+++ b/src/sandbox/index.js
@@ -100,11 +100,13 @@ function start (params, callback) {
     function _checkArc (callback) {
       let check = readArc()
       arc = check.arc
-      if (!quiet && !check.filepath) {
-        update.warn('No Architect project manifest found, using default project')
-      }
-      else {
-        update.done('Found Architect project manifest, starting up')
+      if (!quiet) {
+        if (!check.filepath) {
+          update.warn('No Architect project manifest found, using default project')
+        }
+        else {
+          update.done('Found Architect project manifest, starting up')
+        }
       }
       isDefaultProject = check.isDefaultProject ? true : false
       callback()


### PR DESCRIPTION
When starting the sandbox in tests like `await sandbox.start({ quiet: true })` it shouldn't output anything IMO, but without this PR either a "No Architect project manifest found, using default project" warning or a "Found Architect project manifest, starting up" message would be output-ed instead.

- [x] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes