### PR TITLE
Skip port-checking for external DB

### DIFF
--- a/src/tables/index.js
+++ b/src/tables/index.js
@@ -13,6 +13,7 @@ module.exports = function createTables () {
   let { arc } = readArc()
 
   if (arc.tables) {
+    let hasExternalDb = process.env.ARC_DB_EXTERNAL
     let tables = {}
     let dynamo
 
@@ -31,7 +32,10 @@ module.exports = function createTables () {
 
         // Ensure the port is free
         function _checkPort (callback) {
-          checkPort(tablesPort, callback)
+          if (!hasExternalDb) {
+            checkPort(tablesPort, callback)
+          }
+          else callback()
         },
 
         // Print the banner (which also loads AWS env vars / creds necessary for Dynamo)
@@ -44,7 +48,6 @@ module.exports = function createTables () {
         },
 
         function _startDynalite (callback) {
-          let hasExternalDb = process.env.ARC_DB_EXTERNAL
           if (!hasExternalDb) {
             dynamo = dynalite({ createTableMs: 0 }).listen(tablesPort, callback)
           }


### PR DESCRIPTION
In case of `ARC_DB_EXTERNAL` is truthy, there shouldn't be an
availability check of the database port. But the external DB should
rather check the availability itself.

This fixes a regression introduced with version 2.0.0

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
