### PR TITLE
Run scheduled events on the sandbox server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ node_modules/
 package-lock.json
 test/mock/*/src/*/*/vendor/
 test/mock/*/.db
-TEST_ARGUMENTS
+test/mock/tmp/*

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 package-lock.json
 test/mock/*/src/*/*/vendor/
 test/mock/*/.db
+TEST_ARGUMENTS

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Architect Sandbox changelog
 
+## [2.X.X] XXXX-XX-XX
+
+- Added support for simulating CloudWatch Scheduled Events
+  - Run with --scheduled to activate these
+  - Press `T` while the sandbox is running to trigger all events
+
 ---
 
 ## [3.1.3] 2020-10-19

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@architect/parser": "~2.3.0",
     "@architect/utils": "~1.5.13",
     "@begin/hashid": "~1.0.0",
+    "aws-cron-parser": "~1.1.4",
     "aws-sdk": "~2.644.0",
     "body-parser": "~1.19.0",
     "chalk": "~4.1.0",

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,15 @@ npx arc sandbox
 - `-p`, `--port`, `port` - Manually specify HTTP port
   - Defaults to `3333`
 - `-v`, `--verbose`, `verbose` - Enable verbose logging
+- `-s`, `--scheduled`, `scheduled` - Run scheduled events
 
+### Keyboard Commands
+
+While the Sandbox is running, you can use the following keypresses: (note, they are capital letters)
+
+- `H` - Hydrate all files
+- `S` - Hydrate shared files
+- `V` - Hydrate view files
 
 ### Environment variables
 

--- a/readme.md
+++ b/readme.md
@@ -133,6 +133,16 @@ Invokes `callback` once everything is ready, or returns a `promise` if `callback
 
 Shuts down anything started by `sandbox.tables.start()`. Invokes `callback` once shut down, or returns a `promise` if `callback` is falsy.
 
+### Scheduled (`@scheduled`)
+
+### `sandbox.scheduled.start(options[, callback]) → [Promise]`
+
+Parses the Architect project configuration and runs the [`@scheduled`][scheduled] functions.
+
+### `sandbox.scheduled.end([callback]) → [Promise]`
+
+Shuts down anything started by `sandbox.scheduled.start()`. Invokes `callback` once shut down, or returns a `promise` if `callback` is falsy.
+
 ---
 
 ## Example
@@ -186,4 +196,5 @@ test('Tests go here', () => {
 [http]: https://arc.codes/reference/arc/http
 [queues]: https://arc.codes/reference/arc/queues
 [tables]: https://arc.codes/reference/arc/tables
+[scheduled]: https://arc.codes/reference/arc/scheduled
 [ws]: https://arc.codes/reference/arc/ws

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,7 @@ While the Sandbox is running, you can use the following keypresses: (note, they 
 - `H` - Hydrate all files
 - `S` - Hydrate shared files
 - `V` - Hydrate view files
+- `T` - Trigger all scheduled events
 
 ### Environment variables
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -31,7 +31,7 @@ module.exports = function cli (params = {}, callback) {
     // Setup
     let update = updater('Sandbox')
     let deprecated = process.env.DEPRECATED
-    let watcher = watch(process.cwd(), { recursive: true, filter: f => !/node_modules/.test(f) })
+    let watcher = watch(process.cwd(), { recursive: true })
     let workingDirectory = pathToUnix(process.cwd())
     let separator = path.posix.sep
     let { runScheduled } = readOptions(params.options)

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -178,6 +178,14 @@ module.exports = function cli (params = {}, callback) {
               }
             }
           })
+
+          // Update scheduled events listeners
+          sandbox.scheduled.end()
+          sandbox.scheduled.start({ quiet: true }, function (err) {
+            if (!quiet) delete process.env.ARC_QUIET
+            if (err) return update.err(err)
+            update.done('Scheduled events reloaded')
+          })
         }, 50)
       }
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -9,6 +9,7 @@ let { readArc } = require('../helpers')
 let readline = require('readline')
 let { tmpdir } = require('os')
 let sandbox = require('../sandbox')
+let { runScheduled } = require('../scheduled')
 
 module.exports = function cli (params = {}, callback) {
   if (!params.version) params.version = ver
@@ -109,6 +110,9 @@ module.exports = function cli (params = {}, callback) {
           msg: 'Rehydrating src/views...',
           force: true
         })
+      }
+      if (input === 'T') {
+        runScheduled()
       }
       if (key.sequence === '\u0003') {
         sandbox.end(function (err) {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -10,7 +10,7 @@ let { readArc, readOptions } = require('../helpers')
 let readline = require('readline')
 let { tmpdir } = require('os')
 let sandbox = require('../sandbox')
-let { runScheduled } = require('../scheduled')
+let { scheduledEventsRunner } = require('../scheduled')
 
 module.exports = function cli (params = {}, callback) {
   if (!params.version) params.version = ver
@@ -114,7 +114,7 @@ module.exports = function cli (params = {}, callback) {
         })
       }
       if (input === 'T') {
-        runScheduled()
+        scheduledEventsRunner()
       }
       if (key.sequence === '\u0003') {
         sandbox.end(function (err) {
@@ -165,12 +165,12 @@ module.exports = function cli (params = {}, callback) {
 
           let quiet = process.env.ARC_QUIET
 
-          series ([
-            function _endHttp(callback) {
+          series([
+            function _endHttp (callback) {
               // Always attempt to close the http server, but only reload if necessary
               sandbox.http.end(callback)
             },
-            function _startHttp(callback) {
+            function _startHttp (callback) {
               let start = Date.now()
               process.env.ARC_QUIET = true
               sandbox.http.start({ quiet: true }, function (err, result) {
@@ -186,7 +186,7 @@ module.exports = function cli (params = {}, callback) {
                 callback(err, result)
               })
             },
-            function _maybeHydrate(callback) {
+            function _maybeHydrate (callback) {
               if (deprecated) {
                 rehydrate({
                   timer: rehydrateArcTimer,

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -2,11 +2,13 @@ let env = require('./env')
 let { getPorts, checkPort } = require('./ports')
 let maybeHydrate = require('./maybe-hydrate')
 let readArc = require('./read-arc')
+let readOptions = require('./read-options')
 
 module.exports = {
   env,
   getPorts,
   checkPort,
   maybeHydrate,
-  readArc
+  readArc,
+  readOptions
 }

--- a/src/helpers/read-options.js
+++ b/src/helpers/read-options.js
@@ -1,0 +1,17 @@
+module.exports = function (options) {
+  // Set up verbositude
+  let verbose = false
+  let findVerbose = option => [ '-v', '--verbose', 'verbose' ].includes(option)
+  if (options && options.some(findVerbose)) {
+    verbose = true
+  }
+
+  // Set up scheduled
+  let runScheduled = false
+  let findScheduled = option => [ '-s', '--scheduled', 'scheduled' ].includes(option)
+  if (options && options.some(findScheduled)) {
+    runScheduled = true
+  }
+
+  return { verbose, runScheduled }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 let cli = require('./cli')
-let { tables, events, http, start, end } = require('./sandbox')
+let { tables, events, http, scheduled, start, end } = require('./sandbox')
 
 module.exports = {
   cli,
@@ -7,6 +7,7 @@ module.exports = {
   events,
   http,
   tables,
+  scheduled,
   // Main Sandbox controls
   start,
   end

--- a/src/sandbox/_service-factory.js
+++ b/src/sandbox/_service-factory.js
@@ -1,6 +1,7 @@
 let _events = require('../events')
 let _http = require('../http')
 let _tables = require('../tables')
+let _scheduled = require('../scheduled')
 
 module.exports = function serviceFactory (params) {
   let { server, type, update } = params
@@ -9,6 +10,7 @@ module.exports = function serviceFactory (params) {
   if (t('events'))  init = _events
   if (t('http'))    init = _http
   if (t('tables'))  init = _tables
+  if (t('scheduled'))  init = _scheduled
   return {
     start: function (options, callback) {
       // Set up promise if there's no callback

--- a/src/sandbox/end.js
+++ b/src/sandbox/end.js
@@ -1,7 +1,7 @@
 let series = require('run-series')
 
 module.exports = function end (server, callback) {
-  let { events, http, tables } = server
+  let { events, http, tables, scheduled } = server
 
   // Set up promise if there is no callback
   let promise
@@ -24,6 +24,10 @@ module.exports = function end (server, callback) {
     },
     function _dynamo (callback) {
       if (tables) tables.end(callback)
+      else callback()
+    },
+    function _scheduled (callback) {
+      if (scheduled) scheduled.end(callback)
       else callback()
     }
   ], function closed (err) {

--- a/src/sandbox/index.js
+++ b/src/sandbox/index.js
@@ -13,6 +13,7 @@ let server = {
   events: undefined,
   http: undefined,
   tables: undefined,
+  scheduled: undefined,
 }
 
 /**

--- a/src/sandbox/index.js
+++ b/src/sandbox/index.js
@@ -21,6 +21,7 @@ let server = {
 let events = service({ server, type: 'events', update })
 let http = service({ server, type: 'http', update })
 let tables = service({ server, type: 'tables', update })
+let scheduled = service({ server, type: 'scheduled', update })
 
 /**
  * Run startup routines and start all services
@@ -40,6 +41,7 @@ function start (args = {}, callback) {
     ...args,
     update,
     events,
+    scheduled,
     http,
     tables,
   }, callback)
@@ -51,7 +53,7 @@ function start (args = {}, callback) {
  * Shut everything down
  */
 function end (callback) {
-  return _end({ events, http, tables }, callback)
+  return _end({ events, http, tables, scheduled }, callback)
 }
 
-module.exports = { events, http, tables, start, end }
+module.exports = { events, http, tables, scheduled, start, end }

--- a/src/sandbox/start.js
+++ b/src/sandbox/start.js
@@ -18,6 +18,7 @@ module.exports = function _start (params, callback) {
     // Everything else
     update,
     events,
+    scheduled,
     http,
     tables,
   } = params
@@ -90,6 +91,10 @@ module.exports = function _start (params, callback) {
     // Start event bus (@events) listening for `arc.event.publish` events
     function _events (callback) {
       events.start(params, callback)
+    },
+
+    function _scheduled (callback) {
+      scheduled.start(params, callback)
     },
 
     // Start HTTP + WebSocket (@http, @ws) server

--- a/src/sandbox/start.js
+++ b/src/sandbox/start.js
@@ -33,6 +33,13 @@ module.exports = function _start (params, callback) {
     verbose = true
   }
 
+  // Set up scheduled
+  let runScheduled = false
+  let findScheduled = option => [ '-s', '--scheduled', 'scheduled' ].includes(option)
+  if (options && options.some(findScheduled)) {
+    runScheduled = true
+  }
+
   let { arc, filepath } = readArc()
   let deprecated = process.env.DEPRECATED
 
@@ -93,7 +100,14 @@ module.exports = function _start (params, callback) {
       events.start(params, callback)
     },
 
+    // Run scheduled events from arc file (@scheduled)
+    // requires -s / --scheduled option
     function _scheduled (callback) {
+      if (!runScheduled) {
+        let skipMessage = chalk.grey.dim('use --scheduled option to run scheduled events')
+        console.log(`- ${skipMessage}\n`)
+        return callback()
+      }
       scheduled.start(params, callback)
     },
 

--- a/src/scheduled/_runner.js
+++ b/src/scheduled/_runner.js
@@ -1,0 +1,91 @@
+let { fork } = require('child_process')
+let { join } = require('path')
+let chalk = require('chalk')
+let awsCronParser = require('aws-cron-parser')
+
+const multipliers = [
+  { name: 'minute', multiplier: 1 },
+  { name: 'hour', multiplier: 60 },
+  { name: 'day', multiplier: 24 * 60 }
+]
+
+module.exports = function eventRunner (scheduledEvents) {
+  const quiet = process.env.ARC_QUIET
+  // All times are counted from here:
+  let schedule
+
+  const updateRules = (scheduledEvents) => {
+    const starter = new Date()
+    schedule = scheduledEvents.map(([ name, ...rule ]) => {
+      rule = rule.join(' ')
+      let offset
+      let nextRun
+      let cron
+
+      if (/rate/.test(rule)) { // AWS Schedule Expression
+        const value = parseInt(rule.match(/\d+/), 10)
+        const multiplier = multipliers.find(m => rule.includes(m.name))
+        if (!value || !multiplier) {
+          throw new Error(`Incorrect rule ${rule}`)
+        }
+
+        offset = multiplier.multiplier * value * 60 * 1000
+        nextRun = starter.getTime() + offset
+      } else { // AWS Cron expression (6 items)
+        const cronString = rule.trim().replace('cron(', '').replace(')', '')
+        cron = awsCronParser.parse(cronString)
+        nextRun = awsCronParser.next(cron, starter).getTime()
+      }
+
+      return {
+        offset,
+        nextRun,
+        cron,
+        rule,
+        name
+      }
+    })
+  }
+
+  updateRules(scheduledEvents)
+
+  function checkRun () {
+    const runTime = new Date().getTime()
+
+    const runners = schedule.filter(item => {
+      return runTime >= item.nextRun
+    })
+
+    runners.forEach(item => {
+      if (item.offset) {
+        item.nextRun = runTime + item.offset
+      } else {
+        const next = awsCronParser.next(item.cron, new Date())
+        item.nextRun = next.getTime()
+      }
+      run(item)
+    })
+  }
+
+  function run (item) {
+    // Spawn a fork of the Node process
+    let subprocess = fork(join(__dirname, '_subprocess.js'))
+    subprocess.send(item)
+    subprocess.on('message', function _message (msg) {
+      if (!quiet) {
+        console.log(chalk.grey.dim(msg.text))
+      }
+    })
+  }
+
+  const interval = setInterval(checkRun, 1000 * 30)
+
+  return {
+    updateRules,
+    stop: (cb) => {
+      clearInterval(interval)
+      cb()
+    }
+  }
+}
+

--- a/src/scheduled/_runner.js
+++ b/src/scheduled/_runner.js
@@ -1,6 +1,5 @@
 let { fork } = require('child_process')
 let { join } = require('path')
-let chalk = require('chalk')
 let awsCronParser = require('aws-cron-parser')
 
 const multipliers = [
@@ -83,7 +82,7 @@ module.exports = function eventRunner (scheduledEvents, update) {
     subprocess.send(item)
     subprocess.on('message', function _message (msg) {
       if (!quiet) {
-        console.log(chalk.grey.dim(msg.text))
+        update.status(msg.text)
       }
     })
   }

--- a/src/scheduled/_subprocess.js
+++ b/src/scheduled/_subprocess.js
@@ -1,0 +1,31 @@
+let path = require('path')
+let invoke = require('../invoke-lambda')
+
+process.on('message', function msg (params) {
+  let pathToLambda = path.join(process.cwd(), 'src', 'scheduled', params.name)
+  invoke(pathToLambda, cloudwatchEvent(params), function snap (err) {
+    let text
+    if (err) {
+      text = `@${params.name} ${params.rule} failed with ${err.stack}`
+    }
+    else {
+      text = `@${params.name} ${params.rule} complete`
+    }
+    // send a message to the parent node process
+    process.send({ text })
+    process.exit()
+  })
+})
+
+function cloudwatchEvent () {
+  return {
+    'id': '53dc4d37-cffa-4f76-80c9-8b7d4a4d2eaa',
+    'detail-type': 'Scheduled Event',
+    'source': 'aws.events',
+    'account': '123456789012',
+    'time': new Date().getTime(),
+    'region': 'us-east-1',
+    'resources': [ 'arn:aws:events:us-east-1:123456789012:rule/MyScheduledRule' ],
+    'detail': {}
+  }
+}

--- a/src/scheduled/index.js
+++ b/src/scheduled/index.js
@@ -2,7 +2,6 @@ let { env, maybeHydrate, readArc } = require('../helpers')
 let hydrate = require('@architect/hydrate')
 let runner = require('./_runner')
 let series = require('run-series')
-let readline = require('readline')
 
 // this is a module global
 // so we can run events on key press
@@ -84,6 +83,6 @@ module.exports = function createSchedule () {
   return scheduled
 }
 
-module.exports.runScheduled = function () {
+module.exports.scheduledEventsRunner = function () {
   schedulerBus && schedulerBus.runEvents()
 }

--- a/src/scheduled/index.js
+++ b/src/scheduled/index.js
@@ -1,0 +1,82 @@
+let { env, maybeHydrate, readArc } = require('../helpers')
+let hydrate = require('@architect/hydrate')
+let runner = require('./_runner')
+let series = require('run-series')
+
+/**
+ * Looks for Scheduled Events and runs them as if they were cloudwatch events:
+ */
+module.exports = function createSchedule () {
+  let { arc } = readArc()
+
+  if (!arc.scheduled) {
+    return
+  }
+
+  let scheduled = {}
+  let schedulerBus
+
+
+  scheduled.start = function start (options, callback) {
+    let { all, update } = options
+
+    series([
+      function _env (callback) {
+        if (!all) env(options, callback)
+        else callback()
+      },
+
+      // Loop through functions and see if any need dependency hydration
+      function _maybeHydrate (callback) {
+        if (!all) maybeHydrate(callback)
+        else callback()
+      },
+
+      // ... then hydrate Architect project files into functions
+      function _hydrateShared (callback) {
+        if (!all) {
+          hydrate({ install: false }, function next (err) {
+            if (err) callback(err)
+            else {
+              update.done('Project files hydrated into functions')
+              callback()
+            }
+          })
+        }
+        else callback()
+      },
+
+      function _finalSetup (callback) {
+        try {
+          schedulerBus = runner(arc.scheduled)
+        }
+        catch (e) {
+          callback(e)
+        }
+
+        callback()
+      }
+    ],
+
+    function _started (err) {
+      if (err) callback(err)
+      else {
+        update.done('@scheduled events are running')
+        let msg = 'Scheduler successfully started'
+        callback(null, msg)
+      }
+    })
+  }
+
+  scheduled.end = function end (callback) {
+    schedulerBus.stop(function _closed (err) {
+      if (err) callback(err)
+      else {
+        let msg = 'Scheduled events shut down'
+        callback(null, msg)
+      }
+    })
+  }
+
+  return scheduled
+}

--- a/src/scheduled/index.js
+++ b/src/scheduled/index.js
@@ -4,6 +4,10 @@ let runner = require('./_runner')
 let series = require('run-series')
 let readline = require('readline')
 
+// this is a module global
+// so we can run events on key press
+let schedulerBus
+
 /**
  * Looks for Scheduled Events and runs them as if they were cloudwatch events:
  */
@@ -15,13 +19,6 @@ module.exports = function createSchedule () {
   }
 
   let scheduled = {}
-  let schedulerBus
-
-  function keypress (input) {
-    if (input === 'T') {
-      schedulerBus && schedulerBus.runEvents()
-    }
-  }
 
   scheduled.start = function start (options, callback) {
     let { all, update } = options
@@ -60,12 +57,6 @@ module.exports = function createSchedule () {
           callback(e)
         }
 
-        readline.emitKeypressEvents(process.stdin)
-        if (process.stdin.isTTY) {
-          process.stdin.setRawMode(true)
-        }
-        process.stdin.on('keypress', keypress)
-
         callback()
       }
     ],
@@ -92,4 +83,8 @@ module.exports = function createSchedule () {
   }
 
   return scheduled
+}
+
+module.exports.runScheduled = function () {
+  schedulerBus && schedulerBus.runEvents()
 }

--- a/src/scheduled/index.js
+++ b/src/scheduled/index.js
@@ -72,7 +72,6 @@ module.exports = function createSchedule () {
   }
 
   scheduled.end = function end (callback) {
-    process.stdin.off('keypress', keypress)
     schedulerBus.stop(function _closed (err) {
       if (err) callback(err)
       else {

--- a/test/integration/scheduled-test.js
+++ b/test/integration/scheduled-test.js
@@ -1,0 +1,45 @@
+let sinon = require('sinon')
+let test = require('tape')
+let { join } = require('path')
+let { scheduled } = require('../../src')
+let rateSpy = require('../mock/normal/src/scheduled/rate-scheduled')
+let cronSpy = require('../mock/normal/src/scheduled/cron-scheduled')
+
+const timeoutPromise = time => {
+  return new Promise(resolve => setTimeout(resolve, time))
+}
+
+test('Runs scheduled events from configuration', async t => {
+  process.chdir(join(__dirname, '..', 'mock', 'normal'))
+  await scheduled.end()
+
+  this.clock = sinon.useFakeTimers()
+
+  t.plan(3)
+
+  await rateSpy.resetHistory()
+  await cronSpy.resetHistory()
+
+  await scheduled.start({})
+
+  this.clock.tick(240000)
+
+  this.clock.restore()
+
+  await timeoutPromise(5000)
+
+  const history = await rateSpy.getCalls()
+
+  t.equals(history.length, 2, 'Scheduled Expression spy was called twice in 4 minutes')
+
+  const call1 = history[0][0]
+  const call2 = history[1][0]
+
+  t.notEqual(call1.time, call2.time, 'the different events are given different time')
+
+  const cronHistory = await cronSpy.getCalls()
+
+  t.equals(cronHistory.length, 4, 'Cron-based event were called four times in 4 minutes')
+
+  await scheduled.end()
+})

--- a/test/integration/scheduled-test.js
+++ b/test/integration/scheduled-test.js
@@ -26,6 +26,7 @@ test('Runs scheduled events from configuration', async t => {
 
   this.clock.restore()
 
+  // waiting for the async sub processes to finish
   await timeoutPromise(5000)
 
   const history = await rateSpy.getCalls()

--- a/test/integration/scheduled-test.js
+++ b/test/integration/scheduled-test.js
@@ -34,9 +34,7 @@ test('Runs scheduled events from configuration', async t => {
   t.equals(history.length, 2, 'Scheduled Expression spy was called twice in 4 minutes')
 
   const call1 = history[0][0]
-  const call2 = history[1][0]
-
-  t.notEqual(call1.time, call2.time, 'the different events are given different time')
+  t.ok(call1.time, 'calls the events with a "time" prop')
 
   const cronHistory = await cronSpy.getCalls()
 

--- a/test/integration/scheduled-test.js
+++ b/test/integration/scheduled-test.js
@@ -44,3 +44,8 @@ test('Runs scheduled events from configuration', async t => {
 
   await scheduled.end()
 })
+
+test('Scheduled events test teardown', async () => {
+  await rateSpy.resetHistory()
+  await cronSpy.resetHistory()
+})

--- a/test/mock/normal/.arc
+++ b/test/mock/normal/.arc
@@ -50,3 +50,7 @@ pets
 pets
   accountID *String
   petID **String
+
+@scheduled
+rate-scheduled rate(2 minutes)
+cron-scheduled cron(0/1 * * * ? *)

--- a/test/mock/normal/src/scheduled/cron-scheduled/index.js
+++ b/test/mock/normal/src/scheduled/cron-scheduled/index.js
@@ -1,6 +1,6 @@
-const path = require('path')
-const { writeFile, unlink, readFile } = require('fs').promises
-const EOL = require('os')
+let path = require('path')
+let { writeFile, unlink, readFile } = require('fs').promises
+let EOL = require('os')
 
 /*
  * This test spy is a bit funny.
@@ -9,7 +9,7 @@ const EOL = require('os')
  * and then read them back in in the integration test
  * to be able to make assertions about the calls
  */
-const WRITE_FILENAME = path.join(__dirname, 'TEST_ARGUMENTS')
+let WRITE_FILENAME = path.join(__dirname, '../../../../tmp', 'CRON_ARGUMENTS')
 
 module.exports.handler = async function () {
   return writeFile(WRITE_FILENAME, EOL + JSON.stringify(arguments), { flag: 'a' })

--- a/test/mock/normal/src/scheduled/cron-scheduled/index.js
+++ b/test/mock/normal/src/scheduled/cron-scheduled/index.js
@@ -1,0 +1,44 @@
+const path = require('path')
+const { writeFile, unlink, readFile } = require('fs').promises
+const EOL = require('os')
+
+/*
+ * This test spy is a bit funny.
+ * Because scheduled events are ran in child processes,
+ * i decided to try writing the arguments to file,
+ * and then read them back in in the integration test
+ * to be able to make assertions about the calls
+ */
+const WRITE_FILENAME = path.join(__dirname, 'TEST_ARGUMENTS')
+
+module.exports.handler = async function () {
+  return writeFile(WRITE_FILENAME, EOL + JSON.stringify(arguments), { flag: 'a' })
+}
+
+module.exports.resetHistory = async () => {
+  try {
+    return await unlink(WRITE_FILENAME)
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      // ignore 'file not found, means the test just is not ran yet'
+      return
+    }
+
+    throw e
+  }
+}
+
+
+module.exports.getCalls = async () => {
+  try {
+    const log = await readFile(WRITE_FILENAME, 'utf8')
+    return log.split(EOL).filter(str => str).map(line => JSON.parse(line))
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      // to get better test signal, return 'no calls'
+      return []
+    }
+
+    throw e
+  }
+}

--- a/test/mock/normal/src/scheduled/rate-scheduled/index.js
+++ b/test/mock/normal/src/scheduled/rate-scheduled/index.js
@@ -1,6 +1,6 @@
-const path = require('path')
-const { writeFile, unlink, readFile } = require('fs').promises
-const EOL = require('os')
+let path = require('path')
+let { writeFile, unlink, readFile } = require('fs').promises
+let EOL = require('os')
 
 /*
  * This test spy is a bit funny.
@@ -9,7 +9,7 @@ const EOL = require('os')
  * and then read them back in in the integration test
  * to be able to make assertions about the calls
  */
-const WRITE_FILENAME = path.join(__dirname, 'TEST_ARGUMENTS')
+let WRITE_FILENAME = path.join(__dirname, '../../../../tmp', 'RATE_ARGUMENTS')
 
 module.exports.handler = async function () {
   return writeFile(WRITE_FILENAME, EOL + JSON.stringify(arguments), { flag: 'a' })

--- a/test/mock/normal/src/scheduled/rate-scheduled/index.js
+++ b/test/mock/normal/src/scheduled/rate-scheduled/index.js
@@ -1,0 +1,44 @@
+const path = require('path')
+const { writeFile, unlink, readFile } = require('fs').promises
+const EOL = require('os')
+
+/*
+ * This test spy is a bit funny.
+ * Because scheduled events are ran in child processes,
+ * i decided to try writing the arguments to file,
+ * and then read them back in in the integration test
+ * to be able to make assertions about the calls
+ */
+const WRITE_FILENAME = path.join(__dirname, 'TEST_ARGUMENTS')
+
+module.exports.handler = async function () {
+  return writeFile(WRITE_FILENAME, EOL + JSON.stringify(arguments), { flag: 'a' })
+}
+
+module.exports.resetHistory = async () => {
+  try {
+    return await unlink(WRITE_FILENAME)
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      // ignore 'file not found, means the test just is not ran yet'
+      return
+    }
+
+    throw e
+  }
+}
+
+
+module.exports.getCalls = async () => {
+  try {
+    const log = await readFile(WRITE_FILENAME, 'utf8')
+    return log.split(EOL).filter(str => str).map(line => JSON.parse(line))
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      // to get better test signal, return 'no calls'
+      return []
+    }
+
+    throw e
+  }
+}


### PR DESCRIPTION
Hi!
I thought it would be useful to run the scheduled events on a sandbox server as well.
We have a lot of scheduled events that checks in on some external resource, and pushes new items to a queue. 
This would let us use the sandbox to simulate our entire system. It would be very powerful for us and i hope for others as well.

- [X] Forked the repo and created your branch from `master`
- [X] Made sure tests pass (run `npm it` from the repo root)
- [X] Expanded test coverage related to your changes:
  - [x] Added and/or updated unit tests (if appropriate)
  - [X] Added and/or updated integration tests (if appropriate)
- [X] Updated relevant documentation:
  - [X] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [x] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [x] Summarized your changes in `changelog.md`
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes