### PR TITLE
Fix websocket support

### DIFF
--- a/src/http/index.js
+++ b/src/http/index.js
@@ -102,7 +102,7 @@ module.exports = function createHttpServer () {
           // Bind WebSocket app to HTTP server
           if (arc.ws) {
             let routes = arc.ws
-            websocketServer = registerWS({ app, httpServer, routes })
+            websocketServer = registerWS({ app, server: httpServer, routes })
           }
 
           callback()


### PR DESCRIPTION
Submitting this as a PR since the repo has issues disabled. Sandbox is failing to start with this error:

```
TypeError: Cannot read property 'on' of undefined
    at registerWebSocket ($project/node_modules/@architect/sandbox/src/http/register-websocket/index.js:11:10)
    at Array._finalSetup ($project/node_modules/@architect/sandbox/src/http/index.js:105:31)
    at each ($project/node_modules/run-series/index.js:19:24)
    at Array._hydrateShared ($project/node_modules/@architect/sandbox/src/http/index.js:90:16)
    at each ($project/node_modules/run-series/index.js:19:24)
    at Array._maybeHydrate ($project/node_modules/@architect/sandbox/src/http/index.js:76:16)
    at each ($project/node_modules/run-series/index.js:19:24)
    at next ($project/node_modules/@architect/sandbox/src/http/index.js:68:15)
    at done ($project/node_modules/@architect/utils/fingerprint/index.js:141:7)
    at end ($project/node_modules/run-waterfall/index.js:10:18)
```

This fixes it for me.