### PR TITLE
Fix issue with HTTP + format v1.0 requests not populating certain params when using catchall

### DIFF
--- a/src/http/invoke-http/rest/_req-fmt.js
+++ b/src/http/invoke-http/rest/_req-fmt.js
@@ -38,6 +38,14 @@ module.exports = function requestFormatter ({ method, route, req }, httpApi) {
         : part)
       .join('/')
   }
+  // Handle catchalls
+  if (httpApi && route && route.includes('*')) {
+    resource = route.split('/')
+      .map(part => part === '*'
+        ? `{proxy+}`
+        : part)
+      .join('/')
+  }
 
   // Pass through resource param, importantly: '/' or '/{proxy+}'
   if (req.resource) resource = req.resource
@@ -67,6 +75,13 @@ module.exports = function requestFormatter ({ method, route, req }, httpApi) {
     httpMethod,
     path,
     resourcePath: resource
+  }
+
+  // Path parameters
+  if (httpApi && params && Object.keys(params).length) {
+    request.pathParameters = route && route.endsWith('/*')
+      ? { proxy: params['0'] }
+      : params
   }
 
   return request

--- a/test/integration/http/http-test.js
+++ b/test/integration/http/http-test.js
@@ -180,16 +180,21 @@ test('[HTTP mode] get /deno', t => {
 })
 
 test('[HTTP mode] get /path/*', t => {
-  t.plan(3)
+  t.plan(8)
   tiny.get({
     url: url + '/path/hello/there'
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
       t.ok(result, 'got /path/*')
-      let { message, version } = result.body
+      let { message, version, routeKey, rawPath, pathParameters, requestContext } = result.body
       t.equal(version, '2.0', 'Got Lambda v2.0 payload')
       t.equal(message, 'Hello from get /path/* running the default runtime')
+      t.equal(routeKey, 'GET /path/{proxy+}', 'Got correct routeKey')
+      t.equal(rawPath, '/path/hello/there', 'Got correct rawPath')
+      t.equal(pathParameters.proxy, 'hello/there', 'Got correct pathParameters.proxy')
+      t.equal(requestContext.http.path, '/path/hello/there', 'Got correct requestContext.http.path param')
+      t.equal(requestContext.routeKey, 'GET /path/{proxy+}', 'Got correct requestContext.routeKey param')
     }
   })
 })
@@ -466,18 +471,22 @@ test('[HTTP mode] options /any', t => {
 })
 
 test('[HTTP mode] get /any-c/*', t => {
-  t.plan(5)
+  t.plan(9)
   tiny.get({
     url: url + '/any-c/hello/there',
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
       t.ok(result, 'got /any-c/hello/there')
-      let { message, version, routeKey, requestContext } = result.body
+      let { message, version, routeKey, rawPath, pathParameters, requestContext } = result.body
       t.equal(version, '2.0', 'Got Lambda v2.0 payload')
       t.equal(routeKey, 'ANY /any-c/{proxy+}', 'Got correct routeKey')
-      t.equal(requestContext.http.method, 'GET', 'Got correct method')
       t.equal(message, 'Hello from any /any-c/*', 'Got correct handler response')
+      t.equal(rawPath, '/any-c/hello/there', 'Got correct rawPath')
+      t.equal(pathParameters.proxy, 'hello/there', 'Got correct pathParameters.proxy')
+      t.equal(requestContext.http.method, 'GET', 'Got correct method')
+      t.equal(requestContext.http.path, '/any-c/hello/there', 'Got correct requestContext.http.path param')
+      t.equal(requestContext.routeKey, 'ANY /any-c/{proxy+}', 'Got correct requestContext.routeKey param')
     }
   })
 })

--- a/test/integration/http/httpv1-test.js
+++ b/test/integration/http/httpv1-test.js
@@ -180,16 +180,21 @@ test('[HTTP v1.0 (REST) mode] get /deno', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] get /path/*', t => {
-  t.plan(3)
+  t.plan(8)
   tiny.get({
     url: url + '/path/hello/there'
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
       t.ok(result, 'got /path/*')
-      let { message, version } = result.body
+      let { message, version, resource, path, pathParameters, requestContext } = result.body
       t.equal(version, '1.0', 'Got Lambda v1.0 payload')
       t.equal(message, 'Hello from get /path/* running the default runtime')
+      t.equal(resource, '/path/{proxy+}', 'Got correct resource param')
+      t.equal(path, '/path/hello/there', 'Got correct path param')
+      t.equal(pathParameters.proxy, 'hello/there', 'Got correct pathParameters.proxy')
+      t.equal(requestContext.path, '/path/hello/there', 'Got correct requestContext.path param')
+      t.equal(requestContext.resourcePath, '/path/{proxy+}', 'Got correct requestContext.resourcePath param')
     }
   })
 })
@@ -437,17 +442,22 @@ test('[HTTP v1.0 (REST) mode] options /any', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] get /any-c/*', t => {
-  t.plan(4)
+  t.plan(9)
   tiny.get({
     url: url + '/any-c/hello/there',
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
       t.ok(result, 'got /any-c/hello/there')
-      let { message, version, httpMethod } = result.body
+      let { message, version, httpMethod, resource, path, pathParameters, requestContext } = result.body
       t.equal(version, '1.0', 'Got Lambda v1.0 payload')
       t.equal(httpMethod, 'GET', 'Got correct method')
       t.equal(message, 'Hello from any /any-c/*', 'Got correct handler response')
+      t.equal(resource, '/any-c/{proxy+}', 'Got correct resource param')
+      t.equal(path, '/any-c/hello/there', 'Got correct path param')
+      t.equal(pathParameters.proxy, 'hello/there', 'Got correct pathParameters.proxy')
+      t.equal(requestContext.path, '/any-c/hello/there', 'Got correct requestContext.path param')
+      t.equal(requestContext.resourcePath, '/any-c/{proxy+}', 'Got correct requestContext.resourcePath param')
     }
   })
 })


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
