### PR TITLE
Parse websocket send when ARC_API_TYPE == 'http'

### DIFF
--- a/src/http/middleware/index.js
+++ b/src/http/middleware/index.js
@@ -14,8 +14,7 @@ module.exports = function loadMiddleware (app) {
   let isWSsend = req => req.url === '/__arc'
   let limit = '6mb'
   let parseJson = req => jsonTypes.test(req.headers['content-type']) &&
-                         (!req.isBase64Encoded || isWSsend(req)) &&
-                         process.env.ARC_API_TYPE !== 'http'
+                         (isWSsend(req) || (!req.isBase64Encoded && process.env.ARC_API_TYPE !== 'http'))
   let parseUrlE = req => formURLenc.test(req.headers['content-type']) &&
                          (!req.isBase64Encoded || isWSsend(req))
   app.use(body.json({ limit, type: parseJson }))


### PR DESCRIPTION
The JSON body parser is skipped when ARC_API_TYPE is 'http', but the code that handles that request assumes the body is already parsed.

Seems like this issue was introduced in 3bf6daa09f7fbe13d03b8ba1217c84edcb30105f

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
