### PR TITLE
Refrain from trying to shut down external DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage/
 node_modules/
 package-lock.json
 test/mock/*/src/*/*/vendor/
+test/mock/*/.db

--- a/src/tables/index.js
+++ b/src/tables/index.js
@@ -70,13 +70,16 @@ module.exports = function createTables () {
     }
 
     tables.end = function end (callback) {
-      dynamo.close(function _closed (err) {
-        if (err) callback(err)
-        else {
-          let msg = 'DynamoDB successfully shut down'
-          callback(null, msg)
-        }
-      })
+      if (hasExternalDb) callback()
+      else {
+        dynamo.close(function _closed (err) {
+          if (err) callback(err)
+          else {
+            let msg = 'DynamoDB successfully shut down'
+            callback(null, msg)
+          }
+        })
+      }
     }
 
     return tables

--- a/test/integration/external-table-test.js
+++ b/test/integration/external-table-test.js
@@ -1,0 +1,74 @@
+let { join } = require('path')
+let test = require('tape')
+let dynalite = require('dynalite')
+let { tables } = require('../../src')
+let getDBClient = require('../../src/tables/_get-db-client')
+let dbPort = 4567
+let dynaliteServer
+let dynamo
+
+
+test('Start external DB', t => {
+  t.plan(1)
+  process.env.ARC_DB_EXTERNAL = true
+  process.env.ARC_TABLES_PORT = dbPort
+  process.chdir(join(__dirname, '..', 'mock', 'external-db'))
+  dynaliteServer = dynalite({ path: './.db', createTableMs: 0 })
+  dynaliteServer.listen(dbPort, err => {
+    if (err) t.fail(err)
+    else t.equal(err, undefined, 'Dynalite listening...')
+  })
+})
+
+test('Async tables.start', async t => {
+  t.plan(1)
+  try {
+    let result = await tables.start({})
+    t.equal(result, 'DynamoDB successfully started', 'Tables started')
+  }
+  catch (err) {
+    t.fail(err)
+  }
+})
+
+test('Get client', t => {
+  t.plan(1)
+  getDBClient(function _gotDBClient (err, client) {
+    if (err) console.log(err) // Yes, but actually no
+    dynamo = client
+    t.ok(dynamo, 'Got Dynamo client')
+  })
+})
+
+test('Can list tables', t => {
+  t.plan(1)
+  dynamo.listTables({}, function done (err, result) {
+    if (err) t.fail(err)
+    else {
+      let { TableNames } = result
+      t.ok(Array.isArray(TableNames), `Got tables back from the DB: ${TableNames}`)
+    }
+  })
+})
+
+test('Async tables.end', async t => {
+  t.plan(1)
+  let err
+  try {
+    delete process.env.ARC_DB_EXTERNAL
+    delete process.env.ARC_TABLES_PORT
+    await tables.end()
+  }
+  catch (e) {
+    err = e
+  }
+  t.equal(err, undefined, 'Calling tables.end did not throw error')
+})
+
+test('Stop external DB', t => {
+  t.plan(1)
+  dynaliteServer.close(err => {
+    if (err) t.fail(err)
+    else t.equal(err, undefined, 'DynamoDB successfully shut down')
+  })
+})

--- a/test/mock/external-db/.arc
+++ b/test/mock/external-db/.arc
@@ -1,0 +1,9 @@
+@app
+mockapp
+
+@tables
+accounts
+  accountID *String
+
+pets
+  accountID *String


### PR DESCRIPTION
Currently shutting down errors when using an external DB. This change should fix the situation.

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
