### PR TITLE
Respond to requests to root with only `/:param` defined in `HTTP` APIs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [3.0.4] 2020-10-12
+
+### Fixed
+
+- Fixed obscure false negative for adding Arc Static Asset Proxy when `@http` contains a route that looks like `get /:hey/there`
+
+---
+
 ## [3.0.0 - 3.0.3] 2020-10-08
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Sandbox now respond to requests to root with only `/:param` defined in `HTTP` APIs
+- Improved root handling + ASAP fallthrough behavior
 - Fixed obscure false negative for adding Arc Static Asset Proxy when `@http` contains a route that looks like `get /:hey/there`
 
 ---

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,7 +1,7 @@
 let hydrate = require('@architect/hydrate')
 let path = require('path')
 let fs = require('fs')
-let pkgVer = require('../../package.json').version
+let { version: pkgVer } = require('../../package.json')
 let ver = `Sandbox ${pkgVer}`
 let watch = require('node-watch')
 let { fingerprint, pathToUnix, updater } = require('@architect/utils')

--- a/src/helpers/maybe-hydrate.js
+++ b/src/helpers/maybe-hydrate.js
@@ -1,6 +1,6 @@
 let chalk = require('chalk')
 let depStatus = require('depstatus')
-let exists = require('fs').existsSync
+let { existsSync: exists } = require('fs')
 let glob = require('glob')
 let { join } = require('path')
 let hydrate = require('@architect/hydrate')

--- a/src/http/invoke-http/deprecated/_req-fmt.js
+++ b/src/http/invoke-http/deprecated/_req-fmt.js
@@ -7,8 +7,8 @@ let headerFormatter = require('../rest/_req-header-fmt')
  */
 module.exports = function requestFormatterDeprecated ({ method, req }) {
   let { body, headers, params, url } = req
-  let path = URL.parse(url).pathname
-  let query = URL.parse(url, true).query
+  let { pathname: path } = URL.parse(url)
+  let { query } = URL.parse(url, true)
 
   let { headers: normalizedHeaders } = headerFormatter(headers)
   // Early API Gateway x Lambda integrations coerce 'Cookie' from 'cookie', but not >6.x

--- a/src/http/invoke-http/deprecated/_req-fmt.js
+++ b/src/http/invoke-http/deprecated/_req-fmt.js
@@ -8,7 +8,17 @@ let headerFormatter = require('../rest/_req-header-fmt')
 module.exports = function requestFormatterDeprecated ({ method, req }) {
   let { body, headers, params, url } = req
   let { pathname: path } = URL.parse(url)
-  let { query } = URL.parse(url, true)
+
+  let query = {}
+  let { query: queryData } = URL.parse(url, true)
+  for (let param of Object.keys(queryData)) {
+    if (Array.isArray(queryData[param])) {
+      query[param] = queryData[param][queryData[param].length - 1]
+    }
+    else {
+      query[param] = queryData[param]
+    }
+  }
 
   let { headers: normalizedHeaders } = headerFormatter(headers)
   // Early API Gateway x Lambda integrations coerce 'Cookie' from 'cookie', but not >6.x

--- a/src/http/invoke-http/http/_req-fmt.js
+++ b/src/http/invoke-http/http/_req-fmt.js
@@ -15,8 +15,10 @@ module.exports = function requestFormatter ({ method, route, req }) {
     version: '2.0'
   }
 
-  // Maybe de-interpolate path into resource
+  // Resource may be manually supplied via ASAP
+  // Otherwise rely on route, as defined in arc.http
   resource = resource || route
+
   // Handle route params
   if (route && route.includes(':')) {
     resource = route.split('/')

--- a/src/http/invoke-http/rest/_req-fmt.js
+++ b/src/http/invoke-http/rest/_req-fmt.js
@@ -10,7 +10,8 @@ module.exports = function requestFormatter ({ method, route, req }, httpApi) {
   let { body, params, resource, url } = req
   let { pathname: path } = URL.parse(url)
 
-  // Maybe de-interpolate path into resource
+  // Resource may be manually supplied via ASAP or greedy root
+  // Otherwise rely on route, as defined in arc.http
   resource = resource || route
   if (route && route.includes('/:')) {
     resource = route.split('/')

--- a/src/http/middleware/_fallback.js
+++ b/src/http/middleware/_fallback.js
@@ -78,7 +78,7 @@ module.exports = function fallback (req, res, next) {
   let findRoot = r => {
     let method = r[0].toLowerCase()
     let path = r[1]
-    let rootParam = path.startsWith('/:') && path.split('/:').length === 2
+    let rootParam = path.startsWith('/:') && path.split('/').length === 2
     let isRootMethod = httpAPI
       ? method === 'get' || method === 'any'
       : method === 'get'

--- a/src/http/middleware/_fallback.js
+++ b/src/http/middleware/_fallback.js
@@ -1,5 +1,5 @@
-let exists = require('fs').existsSync
-let join = require('path').join
+let { existsSync: exists } = require('fs')
+let { join } = require('path')
 let { parse } = require('url')
 let invoker = require('../invoke-http')
 let { readArc } = require('../../helpers')

--- a/src/http/middleware/_fallback.js
+++ b/src/http/middleware/_fallback.js
@@ -4,6 +4,7 @@ let { parse } = require('url')
 let invoker = require('../invoke-http')
 let { readArc } = require('../../helpers')
 let httpProxy = require('http-proxy')
+let { getLambdaName: name } = require('@architect/utils')
 
 /**
  * Handle request fallthrough to @proxy + Arc Static Asset Proxy (ASAP)
@@ -48,8 +49,9 @@ module.exports = function fallback (req, res, next) {
 
   // Look for any route parameter matches
   let params = tokens.filter(t => t.some(v => v.startsWith(':')))
-  let paramMatch = params.filter(t => t.length === current.length).some(p => {
-    // Make a copy because we may mutate
+  let paramsFound = params.filter(t => t.length === current.length)
+  let paramsMatch = paramsFound.some(p => {
+    // Make copies because we may mutate
     let t = [ ...p ]
     // Capture 'any' routes (but only in HTTP APIs)
     if (t[0] === 'any' && httpAPI) t[0] = method
@@ -57,6 +59,14 @@ module.exports = function fallback (req, res, next) {
     let exp = t.map(p => p.startsWith(':') ? '(\\S+)' : p).join('/')
     let reg = new RegExp(exp)
     return reg.test(current.join('/'))
+  })
+
+  // Case for HTTP APIs: params at root (`/:param`) handle root requests
+  let rootParamFound = params.filter(t => t.length === 2 && current.length === 1)
+  let rootParam = rootParamFound.find(p => {
+    // Capture 'any' routes
+    if (p[0] === 'any' && httpAPI) p[0] = method
+    return p[0] === current[0]
   })
 
   // Look for a catchall matches
@@ -89,10 +99,10 @@ module.exports = function fallback (req, res, next) {
     return isRootMethod && isRootPath
   }
   let hasRoot = arc.http && arc.http.some(findRoot)
-  let hasASAP = !hasRoot && !arc.proxy && !deprecated
+  let hasASAP = !hasRoot && !arc.proxy && !rootParam && !deprecated
 
   // Bail on exact, param, or catchall matches
-  let match = exactMatch || anyMethodMatch || paramMatch || catchallMatch
+  let match = exactMatch || anyMethodMatch || paramsMatch || catchallMatch
 
   // Backwards compatibility with Arc 6+ REST's greedy `get /` (deprecated in Arc 8)
   let restGreedyRoot = apiType === 'rest' && !deprecated && hasRoot && pathname !== '/'
@@ -120,6 +130,18 @@ module.exports = function fallback (req, res, next) {
     else if (exists(local)) pathToFunction = local
     invokeProxy(pathToFunction)
   }
+  // HTTP APIs can fall back to /:param (REST APIs cannot)
+  else if (rootParam && httpAPI) {
+    let pathToFunction = join(process.cwd(), 'src', 'http', `${rootParam[0]}-${name(rootParam[1])}`)
+    let exec = invoker({
+      method,
+      route: `/${rootParam[1]}`,
+      pathToFunction,
+      apiType
+    })
+    req.params = { [rootParam[1].substr(1)]: '' }
+    exec(req, res)
+  }
   // Arc 6 greedy `get /{proxy+}`
   else if (restGreedyRoot) {
     let pathToFunction = join(process.cwd(), 'src', 'http', `get-index`)
@@ -133,15 +155,16 @@ module.exports = function fallback (req, res, next) {
     res.end(message)
   }
 
-  // Invoke with a proxy payload
+  // Invoke a root proxy payload
   function invokeProxy (pathToFunction) {
     let exec = invoker({
       method,
       pathToFunction,
       apiType
     })
+    let proxy = pathname.startsWith('/') ? pathname.substr(1) : pathname
+    req.params = { proxy }
     req.resource = '/{proxy+}'
-    req.params = { proxy: pathname }
     exec(req, res)
   }
 }

--- a/src/http/register-websocket/get-path.js
+++ b/src/http/register-websocket/get-path.js
@@ -1,4 +1,4 @@
-let join = require('path').join
+let { join } = require('path')
 
 module.exports = function getPath (name) {
   let wsName = name => process.env.DEPRECATED ? `ws-${name}` : name

--- a/src/invoke-lambda/spawn.js
+++ b/src/invoke-lambda/spawn.js
@@ -1,5 +1,5 @@
 let { updater } = require('@architect/utils')
-let spawn = require('child_process').spawn
+let { spawn } = require('child_process')
 let kill = require('tree-kill')
 
 module.exports = function spawnChild (command, args, options, request, timeout, callback) {

--- a/test/integration/events-test.js
+++ b/test/integration/events-test.js
@@ -14,7 +14,7 @@ test('Set up env', t => {
 test('Async events.start', async t => {
   t.plan(1)
   try {
-    let result = await events.start({})
+    let result = await events.start({ quiet: true })
     t.equal(result, 'Event bus successfully started', 'Events started (async)')
   }
   catch (err) {
@@ -50,7 +50,7 @@ test('Async events.end', async t => {
 
 test('Sync events.start', t => {
   t.plan(1)
-  events.start({}, function (err, result) {
+  events.start({ quiet: true }, function (err, result) {
     if (err) t.fail(err)
     else t.equal(result, 'Event bus successfully started', 'Events started (sync)')
   })

--- a/test/integration/events-test.js
+++ b/test/integration/events-test.js
@@ -3,11 +3,12 @@ let test = require('tape')
 let { join } = require('path')
 let { events } = require('../../src')
 let cwd = process.cwd()
+let mock = join(__dirname, '..', 'mock')
 
 test('Set up env', t => {
   t.plan(1)
   t.ok(events, 'Events module is present')
-  process.chdir(join(__dirname, '..', 'mock', 'normal'))
+  process.chdir(join(mock, 'normal'))
 })
 
 test('Async events.start', async t => {

--- a/test/integration/http/_utils.js
+++ b/test/integration/http/_utils.js
@@ -48,7 +48,7 @@ let msgs = {
 
 function checkHttpResult (t, result, checks) {
   t.ok(result, 'Got result!')
-  let { version, body, pathParameters, routeKey, rawPath, requestContext } = result
+  let { version, body, routeKey, rawPath, requestContext } = result
   if (has(result, 'version')) {
     t.equal(version, '2.0', 'Got Lambda v2.0 payload')
   }
@@ -61,9 +61,11 @@ function checkHttpResult (t, result, checks) {
     else if (value === undefined) {
       t.ok(!has(result, param), `${msgs.notReturned}: ${param}`)
     }
-    else if (param === 'pathParameters') {
+    else if (param === 'pathParameters' ||
+             param === 'queryStringParameters' ||
+             param === 'cookies') {
       let val = JSON.stringify(value)
-      t.equal(JSON.stringify(pathParameters), val, `${msgs.correct} ${param}: ${val}`)
+      t.equal(JSON.stringify(result[param]), val, `${msgs.correct} ${param}: ${val}`)
     }
     else if (value === '🤷🏽‍♀️') {
       t.ok(has(result, param), `${msgs.returned} ${param}`)
@@ -95,9 +97,11 @@ function checkRestResult (t, result, checks) {
     else if (value === undefined) {
       t.ok(!has(result, param), `${msgs.notReturned}: ${param}`)
     }
-    else if (param === 'pathParameters') {
+    else if (param === 'pathParameters' ||
+             param === 'queryStringParameters' ||
+             param === 'multiValueQueryStringParameters') {
       let val = JSON.stringify(value)
-      t.equal(JSON.stringify(pathParameters), val, `${msgs.correct} ${param}: ${val}`)
+      t.equal(JSON.stringify(result[param]), val, `${msgs.correct} ${param}: ${val}`)
     }
     else if (value === '🤷🏽‍♀️') {
       t.ok(has(result, param), `${msgs.returned} ${param}`)

--- a/test/integration/http/_utils.js
+++ b/test/integration/http/_utils.js
@@ -7,7 +7,7 @@ let verifyShutdown = (t, err) => {
   t.equal(err.code, 'ECONNREFUSED', 'Sandbox succssfully shut down')
 }
 
-let shutdown = (t) => {
+let shutdown = t => {
   sandbox.end((err, result) => {
     if (err) t.fail(err)
     if (result !== 'Sandbox successfully shut down') {
@@ -22,4 +22,18 @@ let shutdown = (t) => {
   })
 }
 
-module.exports = { url, verifyShutdown, shutdown }
+let shutdownAsync = async t => {
+  let result = await sandbox.end()
+  if (result !== 'Sandbox successfully shut down') {
+    t.fail('Did not get back Sandbox shutdown message')
+  }
+  try {
+    await tiny.get({ url })
+    t.fail('Sandbox did not shut down')
+  }
+  catch (err) {
+    verifyShutdown(t, err)
+  }
+}
+
+module.exports = { url, verifyShutdown, shutdown, shutdownAsync }

--- a/test/integration/http/_utils.js
+++ b/test/integration/http/_utils.js
@@ -148,4 +148,13 @@ function checkDeprecatedResult (t, result, checks) {
   })
 }
 
-module.exports = { url, data, verifyShutdown, shutdown, shutdownAsync, checkHttpResult, checkRestResult, checkDeprecatedResult }
+module.exports = {
+  url,
+  data,
+  verifyShutdown,
+  shutdown,
+  shutdownAsync,
+  checkHttpResult,
+  checkRestResult,
+  checkDeprecatedResult
+}

--- a/test/integration/http/_utils.js
+++ b/test/integration/http/_utils.js
@@ -1,6 +1,9 @@
 let sandbox = require('../../../src')
 let tiny = require('tiny-json-http')
 let url = `http://localhost:${process.env.PORT || 3333}`
+let data = { hi: 'there' }
+let b64dec = i => Buffer.from(i, 'base64').toString()
+let has = (r, p) => Object.hasOwnProperty.call(r, p)
 
 // Verify sandbox shut down
 let verifyShutdown = (t, err) => {
@@ -36,4 +39,69 @@ let shutdownAsync = async t => {
   }
 }
 
-module.exports = { url, verifyShutdown, shutdown, shutdownAsync }
+// Ok, I know this is a bit ridiculous, but I really don't want to have to manually check every param, so let's automate as many checks possible
+let msgs = {
+  correct: 'Returned correct param',
+  returned: 'Returned unverified param',
+  notReturned: 'Did not return'
+}
+
+function checkHttpResult (t, result, checks) {
+  t.ok(result, 'Got result!')
+  let { version, body, pathParameters, routeKey, rawPath, requestContext } = result
+  Object.entries(checks).forEach(([ param, value ]) => {
+    if (param.startsWith('_')) { /* noop */ }
+    else if (param === 'version') t.equal(version, '2.0', 'Got Lambda v2.0 payload')
+    else if (param === 'body' && value) {
+      t.equal(body, JSON.stringify(data), 'Got JSON-serialized body payload')
+    }
+    else if (value === undefined) {
+      t.ok(!has(result, param), `${msgs.notReturned}: ${param}`)
+    }
+    else if (param === 'pathParameters') {
+      let val = JSON.stringify(value)
+      t.equal(JSON.stringify(pathParameters), val, `${msgs.correct} ${param}: ${val}`)
+    }
+    else if (value === '🤷🏽‍♀️') {
+      t.ok(has(result, param), `${msgs.returned} ${param}`)
+    }
+    else {
+      t.equal(result[param], value, `${msgs.correct} ${param}: ${value}`)
+    }
+  })
+  let method = checks._method || routeKey.split(' ')[0]
+  t.equal(requestContext.http.method, method, `Got correct requestContext.http.method param: ${method}`)
+  t.equal(requestContext.http.path, rawPath, `Got correct requestContext.http.path param: ${rawPath}`)
+  t.equal(requestContext.routeKey, routeKey, `Got correct requestContext.routeKey param: ${routeKey}`)
+}
+
+function checkRestResult (t, result, checks) {
+  t.ok(result, 'Got result!')
+  let { version, body, path, pathParameters, httpMethod, resource, requestContext } = result
+  // let { version, body, pathParameters, routeKey, rawPath, requestContext } = result
+  Object.entries(checks).forEach(([ param, value ]) => {
+    if (param.startsWith('_')) { /* noop */ }
+    else if (param === 'version') t.equal(version, '1.0', 'Got Lambda v1.0 payload')
+    else if (param === 'body' && value) {
+      t.equal(b64dec(body), JSON.stringify(data), 'Got JSON-serialized body payload')
+    }
+    else if (value === undefined) {
+      t.ok(!has(result, param), `${msgs.notReturned}: ${param}`)
+    }
+    else if (param === 'pathParameters') {
+      let val = JSON.stringify(value)
+      t.equal(JSON.stringify(pathParameters), val, `${msgs.correct} ${param}: ${val}`)
+    }
+    else if (value === '🤷🏽‍♀️') {
+      t.ok(has(result, param), `${msgs.returned} ${param}`)
+    }
+    else {
+      t.equal(result[param], value, `${msgs.correct} ${param}: ${value}`)
+    }
+  })
+  t.equal(requestContext.httpMethod, httpMethod, `Got correct requestContext.httpMethod param: ${httpMethod}`)
+  t.equal(requestContext.path, path, `Got correct requestContext.path param: ${path}`)
+  t.equal(requestContext.resourcePath, resource, `Got correct requestContext.resourcePath param: ${path}`)
+}
+
+module.exports = { url, data, verifyShutdown, shutdown, shutdownAsync, checkHttpResult, checkRestResult }

--- a/test/integration/http/_utils.js
+++ b/test/integration/http/_utils.js
@@ -49,9 +49,12 @@ let msgs = {
 function checkHttpResult (t, result, checks) {
   t.ok(result, 'Got result!')
   let { version, body, pathParameters, routeKey, rawPath, requestContext } = result
+  if (has(result, 'version')) {
+    t.equal(version, '2.0', 'Got Lambda v2.0 payload')
+  }
+  else t.fail('No Lambda payload version specified')
   Object.entries(checks).forEach(([ param, value ]) => {
     if (param.startsWith('_')) { /* noop */ }
-    else if (param === 'version') t.equal(version, '2.0', 'Got Lambda v2.0 payload')
     else if (param === 'body' && value) {
       t.equal(body, JSON.stringify(data), 'Got JSON-serialized body payload')
     }
@@ -78,10 +81,14 @@ function checkHttpResult (t, result, checks) {
 function checkRestResult (t, result, checks) {
   t.ok(result, 'Got result!')
   let { version, body, path, pathParameters, httpMethod, resource, requestContext } = result
-  // let { version, body, pathParameters, routeKey, rawPath, requestContext } = result
+  if (has(result, 'version')) {
+    t.equal(version, '1.0', 'Got Lambda v1.0 payload')
+  }
+  else {
+    t.notOk(version, 'No Lambda payload version specified')
+  }
   Object.entries(checks).forEach(([ param, value ]) => {
     if (param.startsWith('_')) { /* noop */ }
-    else if (param === 'version') t.equal(version, '1.0', 'Got Lambda v1.0 payload')
     else if (param === 'body' && value) {
       t.equal(b64dec(body), JSON.stringify(data), 'Got JSON-serialized body payload')
     }

--- a/test/integration/http/_utils.js
+++ b/test/integration/http/_utils.js
@@ -82,7 +82,7 @@ function checkHttpResult (t, result, checks) {
 
 function checkRestResult (t, result, checks) {
   t.ok(result, 'Got result!')
-  let { version, body, path, pathParameters, httpMethod, resource, requestContext } = result
+  let { version, body, path, httpMethod, resource, requestContext } = result
   if (has(result, 'version')) {
     t.equal(version, '1.0', 'Got Lambda v1.0 payload')
   }

--- a/test/integration/http/_utils.js
+++ b/test/integration/http/_utils.js
@@ -115,4 +115,37 @@ function checkRestResult (t, result, checks) {
   t.equal(requestContext.resourcePath, resource, `Got correct requestContext.resourcePath param: ${path}`)
 }
 
-module.exports = { url, data, verifyShutdown, shutdown, shutdownAsync, checkHttpResult, checkRestResult }
+function checkDeprecatedResult (t, result, checks) {
+  t.ok(result, 'Got result!')
+  let { version, body } = result
+  if (has(result, 'version')) {
+    t.equal(version, '1.0', 'Got Lambda v1.0 payload')
+  }
+  else {
+    t.notOk(version, 'No Lambda payload version specified')
+  }
+  Object.entries(checks).forEach(([ param, value ]) => {
+    if (param.startsWith('_')) { /* noop */ }
+    else if (value === undefined) {
+      t.ok(!has(result, param), `${msgs.notReturned}: ${param}`)
+    }
+    else if ((typeof result[param] === 'object' &&
+              !Object.keys(result[param]).length) ||
+             param === 'query' ||
+             param === 'queryStringParameters') {
+      let val = JSON.stringify(value)
+      t.equal(JSON.stringify(result[param]), val, `${msgs.correct} ${param}: ${val}`)
+    }
+    else if (param === 'body' && value) {
+      t.equal(JSON.stringify(body), JSON.stringify(data), 'Got JSON-serialized body payload')
+    }
+    else if (value === '🤷🏽‍♀️') {
+      t.ok(has(result, param), `${msgs.returned} ${param}`)
+    }
+    else {
+      t.equal(result[param], value, `${msgs.correct} ${param}: ${value}`)
+    }
+  })
+}
+
+module.exports = { url, data, verifyShutdown, shutdown, shutdownAsync, checkHttpResult, checkRestResult, checkDeprecatedResult }

--- a/test/integration/http/deprecated-test.js
+++ b/test/integration/http/deprecated-test.js
@@ -3,11 +3,10 @@ let tiny = require('tiny-json-http')
 let test = require('tape')
 let sut = join(process.cwd(), 'src')
 let sandbox = require(sut)
-let { url, shutdown } = require('./_utils')
+let { url, data, shutdown, checkDeprecatedResult: checkResult } = require('./_utils')
 
 let cwd = process.cwd()
 let mock = join(__dirname, '..', '..', 'mock')
-let data = { hi: 'there' }
 
 test('Set up env', t => {
   t.plan(1)
@@ -30,160 +29,296 @@ test('[REST mode / deprecated] Start Sandbox', t => {
 })
 
 test('[REST mode / deprecated] get /', t => {
-  t.plan(3)
+  t.plan(12)
   tiny.get({
     url
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /')
-      let { message, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from get / running the default runtime', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get / running the default runtime',
+        path: '/',
+        method: 'GET',
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        query: {},
+        queryStringParameters: {},
+        params: {},
+        body: {},
+        isBase64Encoded: undefined,
+      })
+    }
+  })
+})
+
+test('[REST mode / deprecated] get /?whats=up', t => {
+  t.plan(12)
+  tiny.get({
+    url: url + '/?whats=up'
+  }, function _got (err, result) {
+    if (err) t.fail(err)
+    else {
+      checkResult(t, result.body, {
+        message: 'Hello from get / running the default runtime',
+        path: '/',
+        method: 'GET',
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        query: { whats: 'up' },
+        queryStringParameters: { whats: 'up' },
+        params: {},
+        body: {},
+        isBase64Encoded: undefined,
+      })
+    }
+  })
+})
+
+test('[REST mode / deprecated] get /?whats=up&whats=there', t => {
+  t.plan(12)
+  tiny.get({
+    url: url + '/?whats=up&whats=there'
+  }, function _got (err, result) {
+    if (err) t.fail(err)
+    else {
+      checkResult(t, result.body, {
+        message: 'Hello from get / running the default runtime',
+        path: '/',
+        method: 'GET',
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        query: { whats: 'there' },
+        queryStringParameters: { whats: 'there' },
+        params: {},
+        body: {},
+        isBase64Encoded: undefined,
+      })
     }
   })
 })
 
 test('[REST mode / deprecated] get /binary', t => {
-  t.plan(3)
+  t.plan(12)
+  let path = '/binary'
   tiny.get({
-    url: url + '/binary'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
+      checkResult(t, JSON.parse(result.headers.body), {
+        message: 'Hello from get /binary',
+        path,
+        method: 'GET',
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        query: {},
+        queryStringParameters: {},
+        params: {},
+        isBase64Encoded: undefined,
+      })
       const img = Buffer.from(result.body).toString('base64')
-      t.ok(result, 'got /binary')
-      let { version } = result.headers
-      t.notOk(version, 'No Lambda payload version specified')
       t.ok(img.includes('AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAA'), 'is binary')
     }
   })
 })
 
 test('[REST mode / deprecated] get /nodejs12.x', t => {
-  t.plan(3)
+  t.plan(12)
+  let path = '/nodejs12.x'
   tiny.get({
-    url: url + '/nodejs12.x'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /nodejs12.x')
-      let { message, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from get /nodejs12.x (running nodejs12.x)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /nodejs12.x (running nodejs12.x)',
+        path,
+        method: 'GET',
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        query: {},
+        queryStringParameters: {},
+        params: {},
+        body: {},
+        isBase64Encoded: undefined,
+      })
     }
   })
 })
 
 test('[REST mode / deprecated] get /nodejs10.x', t => {
-  t.plan(3)
+  t.plan(12)
+  let path = '/nodejs10.x'
   tiny.get({
-    url: url + '/nodejs10.x'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /nodejs10.x')
-      let { message, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from get /nodejs10.x (running nodejs10.x)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /nodejs10.x (running nodejs10.x)',
+        path,
+        method: 'GET',
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        query: {},
+        queryStringParameters: {},
+        params: {},
+        body: {},
+        isBase64Encoded: undefined,
+      })
     }
   })
 })
 
 test('[REST mode / deprecated] get /nodejs8.10', t => {
-  t.plan(3)
+  t.plan(12)
+  let path = '/nodejs8.10'
   tiny.get({
-    url: url + '/nodejs8.10'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /nodejs8.10')
-      let { message, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from get /nodejs8.10 (running nodejs8.10)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /nodejs8.10 (running nodejs8.10)',
+        path,
+        method: 'GET',
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        query: {},
+        queryStringParameters: {},
+        params: {},
+        body: {},
+        isBase64Encoded: undefined,
+      })
     }
   })
 })
 
 test('[REST mode / deprecated] get /python3.8', t => {
-  t.plan(3)
+  t.plan(12)
+  let path = '/python3.8'
   tiny.get({
-    url: url + '/python3.8'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /python3.8')
-      let { message, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from get /python3.8 (running python3.8)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /python3.8 (running python3.8)',
+        path,
+        method: 'GET',
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        query: {},
+        queryStringParameters: {},
+        params: {},
+        body: {},
+        isBase64Encoded: undefined,
+      })
     }
   })
 })
 
 test('[REST mode / deprecated] get /python3.7', t => {
-  t.plan(3)
+  t.plan(12)
+  let path = '/python3.7'
   tiny.get({
-    url: url + '/python3.7'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /python3.7')
-      let { message, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from get /python3.7 (running python3.7)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /python3.7 (running python3.7)',
+        path,
+        method: 'GET',
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        query: {},
+        queryStringParameters: {},
+        params: {},
+        body: {},
+        isBase64Encoded: undefined,
+      })
     }
   })
 })
 
 test('[REST mode / deprecated] get /python3.6', t => {
-  t.plan(3)
+  t.plan(12)
+  let path = '/python3.6'
   tiny.get({
-    url: url + '/python3.6'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /python3.6')
-      let { message, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from get /python3.6 (running python3.6)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /python3.6 (running python3.6)',
+        path,
+        method: 'GET',
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        query: {},
+        queryStringParameters: {},
+        params: {},
+        body: {},
+        isBase64Encoded: undefined,
+      })
     }
   })
 })
 
 test('[REST mode / deprecated] get /ruby2.5', t => {
-  t.plan(3)
+  t.plan(12)
+  let path = '/ruby2.5'
   tiny.get({
-    url: url + '/ruby2.5'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /ruby2.5')
-      let { message, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from Architect Sandbox running ruby2.5!', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from Architect Sandbox running ruby2.5!',
+        path,
+        method: 'GET',
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        query: {},
+        queryStringParameters: {},
+        params: {},
+        body: {},
+        isBase64Encoded: undefined,
+      })
     }
   })
 })
 
 test('[REST mode / deprecated] get /deno', t => {
-  t.plan(3)
+  t.plan(12)
+  let path = '/deno'
   tiny.get({
-    url: url + '/deno'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /deno')
-      let { message, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from Architect Sandbox running deno!', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from Architect Sandbox running deno!',
+        path,
+        method: 'GET',
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        query: {},
+        queryStringParameters: {},
+        params: {},
+        body: {},
+        isBase64Encoded: undefined,
+      })
     }
   })
 })
 
 test('[REST mode / deprecated] get /no-return (noop)', t => {
   t.plan(2)
+  let path = '/no-return'
   tiny.get({
-    url: url + '/no-return'
+    url: url + path
   }, function _got (err, result) {
     if (err) {
       let message = 'Async error'
@@ -195,75 +330,102 @@ test('[REST mode / deprecated] get /no-return (noop)', t => {
 })
 
 test('[REST mode / deprecated] post /post', t => {
-  t.plan(5)
+  t.plan(12)
+  let path = '/post'
   tiny.post({
-    url: url + '/post',
+    url: url + path,
     data,
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'posted /post')
-      let { body, message, isBase64Encoded, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from post /post', 'Got correct handler response')
-      // t.equal(b64dec(body), 'hi=there', 'Got base64-encoded form URL-encoded body payload')
-      t.equal(JSON.stringify(body), JSON.stringify(data), 'Got base64-encoded form URL-encoded body payload')
-      t.notOk(isBase64Encoded, 'No isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from post /post',
+        path,
+        method: 'POST',
+        httpMethod: 'POST',
+        headers: '🤷🏽‍♀️',
+        query: {},
+        queryStringParameters: {},
+        params: {},
+        body: data,
+        isBase64Encoded: undefined,
+      })
     }
   })
 })
 
 test('[REST mode / deprecated] put /put', t => {
-  t.plan(5)
+  t.plan(12)
+  let path = '/put'
   tiny.put({
-    url: url + '/put',
+    url: url + path,
     data,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'put /put')
-      let { body, message, isBase64Encoded, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from put /put', 'Got correct handler response')
-      t.equal(JSON.stringify(body), JSON.stringify(data), 'Got base64-encoded JSON-serialized body payload')
-      t.notOk(isBase64Encoded, 'No isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from put /put',
+        path,
+        method: 'PUT',
+        httpMethod: 'PUT',
+        headers: '🤷🏽‍♀️',
+        query: {},
+        queryStringParameters: {},
+        params: {},
+        body: data,
+        isBase64Encoded: undefined,
+      })
     }
   })
 })
 
 test('[REST mode / deprecated] patch /patch', t => {
-  t.plan(5)
+  t.plan(12)
+  let path = '/patch'
   tiny.patch({
-    url: url + '/patch',
+    url: url + path,
     data,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'patched /patch')
-      let { body, message, isBase64Encoded, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from patch /patch', 'Got correct handler response')
-      t.equal(JSON.stringify(body), JSON.stringify(data), 'Got base64-encoded JSON-serialized body payload')
-      t.notOk(isBase64Encoded, 'No isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from patch /patch',
+        path,
+        method: 'PATCH',
+        httpMethod: 'PATCH',
+        headers: '🤷🏽‍♀️',
+        query: {},
+        queryStringParameters: {},
+        params: {},
+        body: data,
+        isBase64Encoded: undefined,
+      })
     }
   })
 })
 
 test('[REST mode / deprecated] delete /delete', t => {
-  t.plan(5)
+  t.plan(12)
+  let path = '/delete'
   tiny.del({
-    url: url + '/delete',
+    url: url + path,
     data,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'deleted /delete')
-      let { body, message, isBase64Encoded, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from delete /delete', 'Got correct handler response')
-      t.equal(JSON.stringify(body), JSON.stringify(data), 'Got base64-encoded JSON-serialized body payload')
-      t.notOk(isBase64Encoded, 'No isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from delete /delete',
+        path,
+        method: 'DELETE',
+        httpMethod: 'DELETE',
+        headers: '🤷🏽‍♀️',
+        query: {},
+        queryStringParameters: {},
+        params: {},
+        body: data,
+        isBase64Encoded: undefined,
+      })
     }
   })
 })
@@ -286,7 +448,7 @@ test('[REST mode / deprecated] post / - route should fail when not explicitly de
 test('[REST mode / deprecated] get /foobar - route should fail when not explicitly defined', t => {
   t.plan(2)
   tiny.get({
-    url: url + '/foobar',
+    url: url + '/foobar'
   }, function _got (err, result) {
     if (err) {
       let message = '@http get /foobar'

--- a/test/integration/http/deprecated-test.js
+++ b/test/integration/http/deprecated-test.js
@@ -1,10 +1,12 @@
-let path = require('path')
+let { join } = require('path')
 let tiny = require('tiny-json-http')
 let test = require('tape')
-let sandbox = require('../../../src')
+let sut = join(process.cwd(), 'src')
+let sandbox = require(sut)
 let { url, shutdown } = require('./_utils')
 
 let cwd = process.cwd()
+let mock = join(__dirname, '..', '..', 'mock')
 let data = { hi: 'there' }
 
 test('Set up env', t => {
@@ -15,7 +17,7 @@ test('Set up env', t => {
 
 test('[REST mode / deprecated] Start Sandbox', t => {
   t.plan(4)
-  process.chdir(path.join(__dirname, '..', '..', 'mock', 'normal'))
+  process.chdir(join(mock, 'normal'))
   sandbox.start({}, function (err, result) {
     if (err) t.fail(err)
     else {
@@ -305,7 +307,7 @@ test('[REST mode / deprecated] Shut down Sandbox', t => {
  */
 test('[REST mode / deprecated] Start Sandbox', t => {
   t.plan(3)
-  process.chdir(path.join(__dirname, '..', '..', 'mock', 'no-index-fail'))
+  process.chdir(join(mock, 'no-index-fail'))
   sandbox.start({}, function (err, result) {
     if (err) t.fail(err)
     else {
@@ -336,7 +338,7 @@ test('[REST mode / deprecated] Shut down Sandbox', t => {
  */
 test('[REST mode / deprecated] Start Sandbox', t => {
   t.plan(3)
-  process.chdir(path.join(__dirname, '..', '..', 'mock', 'no-index-pass'))
+  process.chdir(join(mock, 'no-index-pass'))
   sandbox.start({}, function (err, result) {
     if (err) t.fail(err)
     else {
@@ -367,7 +369,7 @@ test('[REST mode / deprecated] Shut down Sandbox', t => {
  */
 test('[REST mode / deprecated] Start Sandbox', t => {
   t.plan(1)
-  process.chdir(path.join(__dirname, '..', '..', 'mock', 'no-http'))
+  process.chdir(join(mock, 'no-http'))
   sandbox.start({}, function (err, result) {
     if (err) t.fail(err)
     else t.equal(result, 'Sandbox successfully started', 'Sandbox started')

--- a/test/integration/http/deprecated-test.js
+++ b/test/integration/http/deprecated-test.js
@@ -18,7 +18,7 @@ test('Set up env', t => {
 test('[REST mode / deprecated] Start Sandbox', t => {
   t.plan(4)
   process.chdir(join(mock, 'normal'))
-  sandbox.start({}, function (err, result) {
+  sandbox.start({ quiet: true }, function (err, result) {
     if (err) t.fail(err)
     else {
       t.ok(process.env.DEPRECATED, 'Arc v5 deprecated status set')
@@ -308,7 +308,7 @@ test('[REST mode / deprecated] Shut down Sandbox', t => {
 test('[REST mode / deprecated] Start Sandbox', t => {
   t.plan(3)
   process.chdir(join(mock, 'no-index-fail'))
-  sandbox.start({}, function (err, result) {
+  sandbox.start({ quiet: true }, function (err, result) {
     if (err) t.fail(err)
     else {
       t.ok(process.env.DEPRECATED, 'Arc v5 deprecated status set')
@@ -339,7 +339,7 @@ test('[REST mode / deprecated] Shut down Sandbox', t => {
 test('[REST mode / deprecated] Start Sandbox', t => {
   t.plan(3)
   process.chdir(join(mock, 'no-index-pass'))
-  sandbox.start({}, function (err, result) {
+  sandbox.start({ quiet: true }, function (err, result) {
     if (err) t.fail(err)
     else {
       t.ok(process.env.DEPRECATED, 'Arc v5 deprecated status set')
@@ -370,7 +370,7 @@ test('[REST mode / deprecated] Shut down Sandbox', t => {
 test('[REST mode / deprecated] Start Sandbox', t => {
   t.plan(1)
   process.chdir(join(mock, 'no-http'))
-  sandbox.start({}, function (err, result) {
+  sandbox.start({ quiet: true }, function (err, result) {
     if (err) t.fail(err)
     else t.equal(result, 'Sandbox successfully started', 'Sandbox started')
   })

--- a/test/integration/http/http-test.js
+++ b/test/integration/http/http-test.js
@@ -30,7 +30,7 @@ test('[HTTP mode] Start Sandbox', t => {
 })
 
 test('[HTTP mode] get /', t => {
-  t.plan(14)
+  t.plan(15)
   tiny.get({
     url
   }, function _got (err, result) {
@@ -56,7 +56,7 @@ test('[HTTP mode] get /', t => {
 // TODO write some cookie checks
 
 test('[HTTP mode] get /binary', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/binary'
   tiny.get({
     url: url + rawPath
@@ -81,7 +81,7 @@ test('[HTTP mode] get /binary', t => {
 })
 
 test('[HTTP mode] get /nodejs12.x', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/nodejs12.x'
   tiny.get({
     url: url + rawPath
@@ -105,7 +105,7 @@ test('[HTTP mode] get /nodejs12.x', t => {
 })
 
 test('[HTTP mode] get /nodejs10.x', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/nodejs10.x'
   tiny.get({
     url: url + rawPath
@@ -129,7 +129,7 @@ test('[HTTP mode] get /nodejs10.x', t => {
 })
 
 test('[HTTP mode] get /nodejs8.10', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/nodejs8.10'
   tiny.get({
     url: url + rawPath
@@ -153,7 +153,7 @@ test('[HTTP mode] get /nodejs8.10', t => {
 })
 
 test('[HTTP mode] get /python3.8', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/python3.8'
   tiny.get({
     url: url + rawPath
@@ -177,7 +177,7 @@ test('[HTTP mode] get /python3.8', t => {
 })
 
 test('[HTTP mode] get /python3.7', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/python3.7'
   tiny.get({
     url: url + rawPath
@@ -201,7 +201,7 @@ test('[HTTP mode] get /python3.7', t => {
 })
 
 test('[HTTP mode] get /python3.6', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/python3.6'
   tiny.get({
     url: url + rawPath
@@ -225,7 +225,7 @@ test('[HTTP mode] get /python3.6', t => {
 })
 
 test('[HTTP mode] get /ruby2.5', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/ruby2.5'
   tiny.get({
     url: url + rawPath
@@ -249,7 +249,7 @@ test('[HTTP mode] get /ruby2.5', t => {
 })
 
 test('[HTTP mode] get /deno', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/deno'
   tiny.get({
     url: url + rawPath
@@ -273,7 +273,7 @@ test('[HTTP mode] get /deno', t => {
 })
 
 test('[HTTP mode] get /path/*', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/path/hello/there'
   tiny.get({
     url: url + rawPath
@@ -315,7 +315,7 @@ test('[HTTP mode] get /no-return (noop)', t => {
 
 // Write (POST, PUT, etc.) tests exercise HTTP API mode's implicit JSON passthrough
 test('[HTTP mode] post /post (plain JSON)', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/post'
   tiny.post({
     url: url + rawPath,
@@ -340,7 +340,7 @@ test('[HTTP mode] post /post (plain JSON)', t => {
 })
 
 test('[HTTP mode] post /post (flavored JSON)', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/post'
   tiny.post({
     url: url + rawPath,
@@ -366,7 +366,7 @@ test('[HTTP mode] post /post (flavored JSON)', t => {
 })
 
 test('[HTTP mode] put /put', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/put'
   tiny.put({
     url: url + rawPath,
@@ -392,7 +392,7 @@ test('[HTTP mode] put /put', t => {
 })
 
 test('[HTTP mode] patch /patch', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/patch'
   tiny.patch({
     url: url + rawPath,
@@ -417,7 +417,7 @@ test('[HTTP mode] patch /patch', t => {
 })
 
 test('[HTTP mode] delete /delete', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/delete'
   tiny.del({
     url: url + rawPath,
@@ -442,7 +442,7 @@ test('[HTTP mode] delete /delete', t => {
 })
 
 test('[HTTP mode] head /head', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/head'
   tiny.head({
     url: url + rawPath
@@ -466,7 +466,7 @@ test('[HTTP mode] head /head', t => {
 })
 
 test('[HTTP mode] options /options', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/options'
   tiny.options({
     url: url + rawPath
@@ -490,7 +490,7 @@ test('[HTTP mode] options /options', t => {
 })
 
 test('[HTTP mode] get /any', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/any'
   tiny.get({
     url: url + rawPath,
@@ -515,7 +515,7 @@ test('[HTTP mode] get /any', t => {
 })
 
 test('[HTTP mode] post /any', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/any'
   tiny.post({
     url: url + rawPath,
@@ -542,7 +542,7 @@ test('[HTTP mode] post /any', t => {
 })
 
 test('[HTTP mode] put /any', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/any'
   tiny.put({
     url: url + rawPath,
@@ -568,7 +568,7 @@ test('[HTTP mode] put /any', t => {
 })
 
 test('[HTTP mode] patch /any', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/any'
   tiny.patch({
     url: url + rawPath,
@@ -594,7 +594,7 @@ test('[HTTP mode] patch /any', t => {
 })
 
 test('[HTTP mode] delete /any', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/any'
   tiny.del({
     url: url + rawPath,
@@ -620,7 +620,7 @@ test('[HTTP mode] delete /any', t => {
 })
 
 test('[HTTP mode] head /any', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/any'
   tiny.head({
     url: url + rawPath,
@@ -645,7 +645,7 @@ test('[HTTP mode] head /any', t => {
 })
 
 test('[HTTP mode] options /any', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/any'
   tiny.options({
     url: url + rawPath,
@@ -670,7 +670,7 @@ test('[HTTP mode] options /any', t => {
 })
 
 test('[HTTP mode] get /any-c/*', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/any-c/hello/there'
   tiny.get({
     url: url + rawPath,
@@ -695,7 +695,7 @@ test('[HTTP mode] get /any-c/*', t => {
 })
 
 test('[HTTP mode] get /any-p/:param', t => {
-  t.plan(14)
+  t.plan(15)
   let rawPath = '/any-p/hello'
   tiny.get({
     url: url + rawPath,

--- a/test/integration/http/http-test.js
+++ b/test/integration/http/http-test.js
@@ -1,10 +1,12 @@
-let path = require('path')
+let { join } = require('path')
 let tiny = require('tiny-json-http')
 let test = require('tape')
-let sandbox = require('../../../src')
+let sut = join(process.cwd(), 'src')
+let sandbox = require(sut)
 let { url, shutdown } = require('./_utils')
 
 let cwd = process.cwd()
+let mock = join(__dirname, '..', '..', 'mock')
 let b64dec = i => Buffer.from(i, 'base64').toString()
 let data = { hi: 'there' }
 
@@ -16,7 +18,7 @@ test('Set up env', t => {
 
 test('[HTTP mode] Start Sandbox', t => {
   t.plan(4)
-  process.chdir(path.join(__dirname, '..', '..', 'mock', 'normal'))
+  process.chdir(join(mock, 'normal'))
   sandbox.start({}, function (err, result) {
     if (err) t.fail(err)
     else {
@@ -550,7 +552,7 @@ test('[HTTP mode] Shut down Sandbox', t => {
  */
 test('[HTTP mode] Start Sandbox', t => {
   t.plan(3)
-  process.chdir(path.join(__dirname, '..', '..', 'mock', 'no-index-fail'))
+  process.chdir(join(mock, 'no-index-fail'))
   sandbox.start({}, function (err, result) {
     if (err) t.fail(err)
     else {
@@ -581,7 +583,7 @@ test('[HTTP mode] Shut down Sandbox', t => {
  */
 test('[HTTP mode] Start Sandbox', t => {
   t.plan(3)
-  process.chdir(path.join(__dirname, '..', '..', 'mock', 'no-index-pass'))
+  process.chdir(join(mock, 'no-index-pass'))
   sandbox.start({}, function (err, result) {
     if (err) t.fail(err)
     else {
@@ -616,7 +618,7 @@ test('[HTTP mode] Shut down Sandbox', t => {
  */
 test('[HTTP mode] Start Sandbox', t => {
   t.plan(1)
-  process.chdir(path.join(__dirname, '..', '..', 'mock', 'no-http'))
+  process.chdir(join(mock, 'no-http'))
   sandbox.start({}, function (err, result) {
     if (err) t.fail(err)
     else t.equal(result, 'Sandbox successfully started', 'Sandbox started')

--- a/test/integration/http/http-test.js
+++ b/test/integration/http/http-test.js
@@ -9,6 +9,42 @@ let cwd = process.cwd()
 let mock = join(__dirname, '..', '..', 'mock')
 let b64dec = i => Buffer.from(i, 'base64').toString()
 let data = { hi: 'there' }
+let has = (r, p) => Object.hasOwnProperty.call(r, p)
+
+// Ok, I know this is a bit ridiculous, but I really don't want to have to manually check every param, so let's automate as many checks possible
+function checkResult (t, result, checks) {
+  t.ok(result, 'Got result!')
+  let msgs = {
+    correct: 'Returned correct param',
+    returned: 'Returned unverified param',
+    notReturned: 'Did not return'
+  }
+  let { version, body, pathParameters, routeKey, rawPath, requestContext } = result
+  Object.entries(checks).forEach(([ param, value ]) => {
+    if (param.startsWith('_')) { /* noop */ }
+    else if (param === 'version') t.equal(version, '2.0', 'Got Lambda v2.0 payload')
+    else if (param === 'body' && value) {
+      t.equal(body, JSON.stringify(data), 'Got JSON-serialized body payload')
+    }
+    else if (value === undefined) {
+      t.ok(!has(result, param), `${msgs.notReturned}: ${param}`)
+    }
+    else if (param === 'pathParameters') {
+      let val = JSON.stringify(value)
+      t.equal(JSON.stringify(pathParameters), val, `${msgs.correct} ${param}: ${val}`)
+    }
+    else if (value === '🤷🏽‍♀️') {
+      t.ok(has(result, param), `${msgs.returned} ${param}`)
+    }
+    else {
+      t.equal(result[param], value, `${msgs.correct} ${param}: ${value}`)
+    }
+  })
+  let method = checks._method || routeKey.split(' ')[0]
+  t.equal(requestContext.http.method, method, `Got correct requestContext.http.method param: ${method}`)
+  t.equal(requestContext.http.path, rawPath, `Got correct requestContext.http.path param: ${rawPath}`)
+  t.equal(requestContext.routeKey, routeKey, `Got correct requestContext.routeKey param: ${routeKey}`)
+}
 
 test('Set up env', t => {
   t.plan(1)
@@ -31,180 +67,277 @@ test('[HTTP mode] Start Sandbox', t => {
 })
 
 test('[HTTP mode] get /', t => {
-  t.plan(3)
+  t.plan(14)
   tiny.get({
     url
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /')
-      let { message, version } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(message, 'Hello from get / running the default runtime', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get / running the default runtime',
+        routeKey: 'GET /',
+        rawPath: '/',
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: undefined,
+      })
     }
   })
 })
 
+// TODO write some query string checks
+// TODO write some cookie checks
+
 test('[HTTP mode] get /binary', t => {
-  t.plan(3)
+  t.plan(14)
+  let rawPath = '/binary'
   tiny.get({
-    url: url + '/binary'
+    url: url + rawPath
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
+      checkResult(t, JSON.parse(result.headers.body), {
+        message: 'Hello from get /binary',
+        routeKey: 'GET /binary',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+      })
       const img = Buffer.from(result.body).toString('base64')
-      t.ok(result, 'got /binary')
-      let { version } = result.headers
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.ok(img.includes('AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAA'), 'is binary')
+      t.ok(img.includes('AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAA'), 'Body payload is binary')
     }
   })
 })
 
 test('[HTTP mode] get /nodejs12.x', t => {
-  t.plan(3)
+  t.plan(14)
+  let rawPath = '/nodejs12.x'
   tiny.get({
-    url: url + '/nodejs12.x'
+    url: url + rawPath
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /nodejs12.x')
-      let { message, version } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(message, 'Hello from get /nodejs12.x (running nodejs12.x)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /nodejs12.x (running nodejs12.x)',
+        routeKey: 'GET /nodejs12.x',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: undefined,
+      })
     }
   })
 })
 
 test('[HTTP mode] get /nodejs10.x', t => {
-  t.plan(3)
+  t.plan(14)
+  let rawPath = '/nodejs10.x'
   tiny.get({
-    url: url + '/nodejs10.x'
+    url: url + rawPath
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /nodejs10.x')
-      let { message, version } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(message, 'Hello from get /nodejs10.x (running nodejs10.x)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /nodejs10.x (running nodejs10.x)',
+        routeKey: 'GET /nodejs10.x',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: undefined,
+      })
     }
   })
 })
 
 test('[HTTP mode] get /nodejs8.10', t => {
-  t.plan(3)
+  t.plan(14)
+  let rawPath = '/nodejs8.10'
   tiny.get({
-    url: url + '/nodejs8.10'
+    url: url + rawPath
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /nodejs8.10')
-      let { message, version } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(message, 'Hello from get /nodejs8.10 (running nodejs8.10)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /nodejs8.10 (running nodejs8.10)',
+        routeKey: 'GET /nodejs8.10',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: undefined,
+      })
     }
   })
 })
 
 test('[HTTP mode] get /python3.8', t => {
-  t.plan(3)
+  t.plan(14)
+  let rawPath = '/python3.8'
   tiny.get({
-    url: url + '/python3.8'
+    url: url + rawPath
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /python3.8')
-      let { message, version } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(message, 'Hello from get /python3.8 (running python3.8)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /python3.8 (running python3.8)',
+        routeKey: 'GET /python3.8',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: undefined,
+      })
     }
   })
 })
 
 test('[HTTP mode] get /python3.7', t => {
-  t.plan(3)
+  t.plan(14)
+  let rawPath = '/python3.7'
   tiny.get({
-    url: url + '/python3.7'
+    url: url + rawPath
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /python3.7')
-      let { message, version } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(message, 'Hello from get /python3.7 (running python3.7)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /python3.7 (running python3.7)',
+        routeKey: 'GET /python3.7',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: undefined,
+      })
     }
   })
 })
 
 test('[HTTP mode] get /python3.6', t => {
-  t.plan(3)
+  t.plan(14)
+  let rawPath = '/python3.6'
   tiny.get({
-    url: url + '/python3.6'
+    url: url + rawPath
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /python3.6')
-      let { message, version } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(message, 'Hello from get /python3.6 (running python3.6)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /python3.6 (running python3.6)',
+        routeKey: 'GET /python3.6',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: undefined,
+      })
     }
   })
 })
 
 test('[HTTP mode] get /ruby2.5', t => {
-  t.plan(3)
+  t.plan(14)
+  let rawPath = '/ruby2.5'
   tiny.get({
-    url: url + '/ruby2.5'
+    url: url + rawPath
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /ruby2.5')
-      let { message, version } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(message, 'Hello from Architect Sandbox running ruby2.5!', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from Architect Sandbox running ruby2.5!',
+        routeKey: 'GET /ruby2.5',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: undefined,
+      })
     }
   })
 })
 
 test('[HTTP mode] get /deno', t => {
-  t.plan(3)
+  t.plan(14)
+  let rawPath = '/deno'
   tiny.get({
-    url: url + '/deno'
+    url: url + rawPath
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /deno')
-      let { message, version } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(message, 'Hello from Architect Sandbox running deno!', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from Architect Sandbox running deno!',
+        routeKey: 'GET /deno',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: undefined,
+      })
     }
   })
 })
 
 test('[HTTP mode] get /path/*', t => {
-  t.plan(8)
+  t.plan(14)
+  let rawPath = '/path/hello/there'
   tiny.get({
-    url: url + '/path/hello/there'
+    url: url + rawPath
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /path/*')
-      let { message, version, routeKey, rawPath, pathParameters, requestContext } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(message, 'Hello from get /path/* running the default runtime')
-      t.equal(routeKey, 'GET /path/{proxy+}', 'Got correct routeKey')
-      t.equal(rawPath, '/path/hello/there', 'Got correct rawPath')
-      t.equal(pathParameters.proxy, 'hello/there', 'Got correct pathParameters.proxy')
-      t.equal(requestContext.http.path, '/path/hello/there', 'Got correct requestContext.http.path param')
-      t.equal(requestContext.routeKey, 'GET /path/{proxy+}', 'Got correct requestContext.routeKey param')
+      checkResult(t, result.body, {
+        message: 'Hello from get /path/* running the default runtime',
+        routeKey: 'GET /path/{proxy+}',
+        rawPath,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        pathParameters: { proxy: 'hello/there' },
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: undefined,
+      })
     }
   })
 })
 
 test('[HTTP mode] get /no-return (noop)', t => {
   t.plan(3)
+  let rawPath = '/no-return'
   tiny.get({
-    url: url + '/no-return'
+    url: url + rawPath
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
@@ -219,293 +352,406 @@ test('[HTTP mode] get /no-return (noop)', t => {
 
 // Write (POST, PUT, etc.) tests exercise HTTP API mode's implicit JSON passthrough
 test('[HTTP mode] post /post (plain JSON)', t => {
-  t.plan(5)
+  t.plan(14)
+  let rawPath = '/post'
   tiny.post({
-    url: url + '/post',
+    url: url + rawPath,
     data,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'posted /post')
-      let { body, message, isBase64Encoded, version } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(message, 'Hello from post /post', 'Got correct handler response')
-      t.equal(body, JSON.stringify(data), 'Got JSON-serialized body payload')
-      t.equal(isBase64Encoded, false, 'Got isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from post /post',
+        routeKey: 'POST /post',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: true,
+      })
     }
   })
 })
 
 test('[HTTP mode] post /post (flavored JSON)', t => {
-  t.plan(5)
+  t.plan(14)
+  let rawPath = '/post'
   tiny.post({
-    url: url + '/post',
+    url: url + rawPath,
     data,
     headers: { 'Content-Type': 'application/ld+json' }, // Exercise the JSON regex
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'posted /post')
-      let { body, message, isBase64Encoded, version } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(message, 'Hello from post /post', 'Got correct handler response')
-      t.equal(body, JSON.stringify(data), 'Got JSON-serialized body payload')
-      t.equal(isBase64Encoded, false, 'Got isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from post /post',
+        routeKey: 'POST /post',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: true,
+      })
     }
   })
 })
 
 test('[HTTP mode] put /put', t => {
-  t.plan(5)
+  t.plan(14)
+  let rawPath = '/put'
   tiny.put({
-    url: url + '/put',
+    url: url + rawPath,
     data,
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'put /put')
-      let { body, message, isBase64Encoded, version } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(message, 'Hello from put /put', 'Got correct handler response')
-      t.equal(b64dec(body), 'hi=there', 'Got base64-encoded form URL-encoded body payload')
-      t.ok(isBase64Encoded, 'Got isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from put /put',
+        routeKey: 'PUT /put',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: true,
+      })
+      t.equal(b64dec(result.body.body), 'hi=there', 'Got base64-encoded form URL-encoded body payload')
     }
   })
 })
 
 test('[HTTP mode] patch /patch', t => {
-  t.plan(5)
+  t.plan(14)
+  let rawPath = '/patch'
   tiny.patch({
-    url: url + '/patch',
+    url: url + rawPath,
     data,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'patched /patch')
-      let { body, message, isBase64Encoded, version } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(message, 'Hello from patch /patch', 'Got correct handler response')
-      t.equal(body, JSON.stringify(data), 'Got JSON-serialized body payload')
-      t.equal(isBase64Encoded, false, 'Got isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from patch /patch',
+        routeKey: 'PATCH /patch',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: true,
+      })
     }
   })
 })
 
 test('[HTTP mode] delete /delete', t => {
-  t.plan(5)
+  t.plan(14)
+  let rawPath = '/delete'
   tiny.del({
-    url: url + '/delete',
+    url: url + rawPath,
     data,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'deleted /delete')
-      let { body, message, isBase64Encoded, version } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(message, 'Hello from delete /delete', 'Got correct handler response')
-      t.equal(body, JSON.stringify(data), 'Got JSON-serialized body payload')
-      t.equal(isBase64Encoded, false, 'Got isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from delete /delete',
+        routeKey: 'DELETE /delete',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: true,
+      })
     }
   })
 })
 
 test('[HTTP mode] head /head', t => {
-  t.plan(3)
+  t.plan(14)
+  let rawPath = '/head'
   tiny.head({
-    url: url + '/head'
+    url: url + rawPath
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'headed /head')
-      let { message, version } = JSON.parse(result.headers.body)
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(message, 'Hello from head /head', 'Got correct handler response')
+      checkResult(t, JSON.parse(result.headers.body), {
+        message: 'Hello from head /head',
+        routeKey: 'HEAD /head',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: undefined,
+      })
     }
   })
 })
 
 test('[HTTP mode] options /options', t => {
-  t.plan(3)
+  t.plan(14)
+  let rawPath = '/options'
   tiny.options({
-    url: url + '/options'
+    url: url + rawPath
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'optioned /options')
-      let { message, version } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(message, 'Hello from options /options', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from options /options',
+        routeKey: 'OPTIONS /options',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: undefined,
+      })
     }
   })
 })
 
 test('[HTTP mode] get /any', t => {
-  t.plan(5)
+  t.plan(14)
+  let rawPath = '/any'
   tiny.get({
-    url: url + '/any',
+    url: url + rawPath,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /any')
-      let { message, version, routeKey, requestContext } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(routeKey, 'ANY /any', 'Got correct routeKey')
-      t.equal(requestContext.http.method, 'GET', 'Got correct method')
-      t.equal(message, 'Hello from any /any', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from any /any',
+        routeKey: 'ANY /any',
+        _method: 'GET',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: undefined,
+      })
     }
   })
 })
 
 test('[HTTP mode] post /any', t => {
-  t.plan(7)
+  t.plan(14)
+  let rawPath = '/any'
   tiny.post({
-    url: url + '/any',
+    url: url + rawPath,
     data,
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'posted /any')
-      let { body, message, isBase64Encoded, version, routeKey, requestContext } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(routeKey, 'ANY /any', 'Got correct routeKey')
-      t.equal(requestContext.http.method, 'POST', 'Got correct method')
-      t.equal(message, 'Hello from any /any', 'Got correct handler response')
-      t.equal(b64dec(body), 'hi=there', 'Got base64-encoded form URL-encoded body payload')
-      t.ok(isBase64Encoded, 'Got isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from any /any',
+        routeKey: 'ANY /any',
+        _method: 'POST',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: true,
+      })
+      t.equal(b64dec(result.body.body), 'hi=there', 'Got base64-encoded form URL-encoded body payload')
     }
   })
 })
 
 test('[HTTP mode] put /any', t => {
-  t.plan(7)
+  t.plan(14)
+  let rawPath = '/any'
   tiny.put({
-    url: url + '/any',
+    url: url + rawPath,
     data,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'put /any')
-      let { body, message, isBase64Encoded, version, routeKey, requestContext } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(routeKey, 'ANY /any', 'Got correct routeKey')
-      t.equal(requestContext.http.method, 'PUT', 'Got correct method')
-      t.equal(message, 'Hello from any /any', 'Got correct handler response')
-      t.equal(body, JSON.stringify(data), 'Got JSON-serialized body payload')
-      t.equal(isBase64Encoded, false, 'Got isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from any /any',
+        routeKey: 'ANY /any',
+        _method: 'PUT',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: true,
+      })
     }
   })
 })
 
 test('[HTTP mode] patch /any', t => {
-  t.plan(7)
+  t.plan(14)
+  let rawPath = '/any'
   tiny.patch({
-    url: url + '/any',
+    url: url + rawPath,
     data,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'patched /any')
-      let { body, message, isBase64Encoded, version, routeKey, requestContext } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(routeKey, 'ANY /any', 'Got correct routeKey')
-      t.equal(requestContext.http.method, 'PATCH', 'Got correct method')
-      t.equal(message, 'Hello from any /any', 'Got correct handler response')
-      t.equal(body, JSON.stringify(data), 'Got JSON-serialized body payload')
-      t.equal(isBase64Encoded, false, 'Got isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from any /any',
+        routeKey: 'ANY /any',
+        _method: 'PATCH',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: true,
+      })
     }
   })
 })
 
 test('[HTTP mode] delete /any', t => {
-  t.plan(7)
+  t.plan(14)
+  let rawPath = '/any'
   tiny.del({
-    url: url + '/any',
+    url: url + rawPath,
     data,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'deleted /any')
-      let { body, message, isBase64Encoded, version, routeKey, requestContext } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(routeKey, 'ANY /any', 'Got correct routeKey')
-      t.equal(requestContext.http.method, 'DELETE', 'Got correct method')
-      t.equal(message, 'Hello from any /any', 'Got correct handler response')
-      t.equal(body, JSON.stringify(data), 'Got JSON-serialized body payload')
-      t.equal(isBase64Encoded, false, 'Got isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from any /any',
+        routeKey: 'ANY /any',
+        _method: 'DELETE',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: true,
+      })
     }
   })
 })
 
 test('[HTTP mode] head /any', t => {
-  t.plan(5)
+  t.plan(14)
+  let rawPath = '/any'
   tiny.head({
-    url: url + '/any',
+    url: url + rawPath,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'headed /any')
-      let { message, version, routeKey, requestContext } = JSON.parse(result.headers.body)
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(routeKey, 'ANY /any', 'Got correct routeKey')
-      t.equal(requestContext.http.method, 'HEAD', 'Got correct method')
-      t.equal(message, 'Hello from any /any', 'Got correct handler response')
+      checkResult(t, JSON.parse(result.headers.body), {
+        message: 'Hello from any /any',
+        routeKey: 'ANY /any',
+        _method: 'HEAD',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: undefined,
+      })
     }
   })
 })
 
 test('[HTTP mode] options /any', t => {
-  t.plan(5)
+  t.plan(14)
+  let rawPath = '/any'
   tiny.options({
-    url: url + '/any',
+    url: url + rawPath,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'optioned /any')
-      let { message, version, routeKey, requestContext } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(routeKey, 'ANY /any', 'Got correct routeKey')
-      t.equal(requestContext.http.method, 'OPTIONS', 'Got correct method')
-      t.equal(message, 'Hello from any /any', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from any /any',
+        routeKey: 'ANY /any',
+        _method: 'OPTIONS',
+        rawPath,
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: undefined,
+      })
     }
   })
 })
 
 test('[HTTP mode] get /any-c/*', t => {
-  t.plan(9)
+  t.plan(14)
+  let rawPath = '/any-c/hello/there'
   tiny.get({
-    url: url + '/any-c/hello/there',
+    url: url + rawPath,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /any-c/hello/there')
-      let { message, version, routeKey, rawPath, pathParameters, requestContext } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(routeKey, 'ANY /any-c/{proxy+}', 'Got correct routeKey')
-      t.equal(message, 'Hello from any /any-c/*', 'Got correct handler response')
-      t.equal(rawPath, '/any-c/hello/there', 'Got correct rawPath')
-      t.equal(pathParameters.proxy, 'hello/there', 'Got correct pathParameters.proxy')
-      t.equal(requestContext.http.method, 'GET', 'Got correct method')
-      t.equal(requestContext.http.path, '/any-c/hello/there', 'Got correct requestContext.http.path param')
-      t.equal(requestContext.routeKey, 'ANY /any-c/{proxy+}', 'Got correct requestContext.routeKey param')
+      checkResult(t, result.body, {
+        message: 'Hello from any /any-c/*',
+        routeKey: 'ANY /any-c/{proxy+}',
+        _method: 'GET',
+        rawPath,
+        pathParameters: { proxy: 'hello/there' },
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: undefined,
+      })
     }
   })
 })
 
 test('[HTTP mode] get /any-p/:param', t => {
-  t.plan(5)
+  t.plan(14)
+  let rawPath = '/any-p/hello'
   tiny.get({
-    url: url + '/any-p/hello',
+    url: url + rawPath,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /any-p/hello')
-      let { message, version, routeKey, requestContext } = result.body
-      t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-      t.equal(routeKey, 'ANY /any-p/{param}', 'Got correct routeKey')
-      t.equal(requestContext.http.method, 'GET', 'Got correct method')
-      t.equal(message, 'Hello from any /any-p/:param', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from any /any-p/:param',
+        routeKey: 'ANY /any-p/{param}',
+        _method: 'GET',
+        rawPath,
+        pathParameters: { param: 'hello' },
+        cookies: undefined,
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: undefined,
+      })
     }
   })
 })

--- a/test/integration/http/http-test.js
+++ b/test/integration/http/http-test.js
@@ -508,6 +508,9 @@ test('[HTTP mode] get /any-p/:param', t => {
   })
 })
 
+/**
+ * Arc v8+: routes are now literal, no more greedy root (`any /{proxy+}`) fallthrough
+ */
 test('[HTTP mode] post / - route should fail when not explicitly defined', t => {
   t.plan(2)
   tiny.post({

--- a/test/integration/http/http-test.js
+++ b/test/integration/http/http-test.js
@@ -19,7 +19,7 @@ test('Set up env', t => {
 test('[HTTP mode] Start Sandbox', t => {
   t.plan(4)
   process.chdir(join(mock, 'normal'))
-  sandbox.start({}, function (err, result) {
+  sandbox.start({ quiet: true }, function (err, result) {
     if (err) t.fail(err)
     else {
       t.notOk(process.env.DEPRECATED, 'Arc v5 deprecated status NOT set')
@@ -553,7 +553,7 @@ test('[HTTP mode] Shut down Sandbox', t => {
 test('[HTTP mode] Start Sandbox', t => {
   t.plan(3)
   process.chdir(join(mock, 'no-index-fail'))
-  sandbox.start({}, function (err, result) {
+  sandbox.start({ quiet: true }, function (err, result) {
     if (err) t.fail(err)
     else {
       t.notOk(process.env.DEPRECATED, 'Arc v5 deprecated status NOT set')
@@ -584,7 +584,7 @@ test('[HTTP mode] Shut down Sandbox', t => {
 test('[HTTP mode] Start Sandbox', t => {
   t.plan(3)
   process.chdir(join(mock, 'no-index-pass'))
-  sandbox.start({}, function (err, result) {
+  sandbox.start({ quiet: true }, function (err, result) {
     if (err) t.fail(err)
     else {
       t.notOk(process.env.DEPRECATED, 'Arc v5 deprecated status NOT set')
@@ -619,7 +619,7 @@ test('[HTTP mode] Shut down Sandbox', t => {
 test('[HTTP mode] Start Sandbox', t => {
   t.plan(1)
   process.chdir(join(mock, 'no-http'))
-  sandbox.start({}, function (err, result) {
+  sandbox.start({ quiet: true }, function (err, result) {
     if (err) t.fail(err)
     else t.equal(result, 'Sandbox successfully started', 'Sandbox started')
   })

--- a/test/integration/http/http-test.js
+++ b/test/integration/http/http-test.js
@@ -3,48 +3,11 @@ let tiny = require('tiny-json-http')
 let test = require('tape')
 let sut = join(process.cwd(), 'src')
 let sandbox = require(sut)
-let { url, shutdown } = require('./_utils')
+let { url, data, shutdown, checkHttpResult: checkResult } = require('./_utils')
 
 let cwd = process.cwd()
 let mock = join(__dirname, '..', '..', 'mock')
 let b64dec = i => Buffer.from(i, 'base64').toString()
-let data = { hi: 'there' }
-let has = (r, p) => Object.hasOwnProperty.call(r, p)
-
-// Ok, I know this is a bit ridiculous, but I really don't want to have to manually check every param, so let's automate as many checks possible
-function checkResult (t, result, checks) {
-  t.ok(result, 'Got result!')
-  let msgs = {
-    correct: 'Returned correct param',
-    returned: 'Returned unverified param',
-    notReturned: 'Did not return'
-  }
-  let { version, body, pathParameters, routeKey, rawPath, requestContext } = result
-  Object.entries(checks).forEach(([ param, value ]) => {
-    if (param.startsWith('_')) { /* noop */ }
-    else if (param === 'version') t.equal(version, '2.0', 'Got Lambda v2.0 payload')
-    else if (param === 'body' && value) {
-      t.equal(body, JSON.stringify(data), 'Got JSON-serialized body payload')
-    }
-    else if (value === undefined) {
-      t.ok(!has(result, param), `${msgs.notReturned}: ${param}`)
-    }
-    else if (param === 'pathParameters') {
-      let val = JSON.stringify(value)
-      t.equal(JSON.stringify(pathParameters), val, `${msgs.correct} ${param}: ${val}`)
-    }
-    else if (value === '🤷🏽‍♀️') {
-      t.ok(has(result, param), `${msgs.returned} ${param}`)
-    }
-    else {
-      t.equal(result[param], value, `${msgs.correct} ${param}: ${value}`)
-    }
-  })
-  let method = checks._method || routeKey.split(' ')[0]
-  t.equal(requestContext.http.method, method, `Got correct requestContext.http.method param: ${method}`)
-  t.equal(requestContext.http.path, rawPath, `Got correct requestContext.http.path param: ${rawPath}`)
-  t.equal(requestContext.routeKey, routeKey, `Got correct requestContext.routeKey param: ${routeKey}`)
-}
 
 test('Set up env', t => {
   t.plan(1)

--- a/test/integration/http/http-test.js
+++ b/test/integration/http/http-test.js
@@ -52,8 +52,78 @@ test('[HTTP mode] get /', t => {
   })
 })
 
-// TODO write some query string checks
-// TODO write some cookie checks
+test('[HTTP mode] get /?whats=up', t => {
+  t.plan(15)
+  let rawQueryString = 'whats=up'
+  tiny.get({
+    url: url + '/?' + rawQueryString
+  }, function _got (err, result) {
+    if (err) t.fail(err)
+    else {
+      checkResult(t, result.body, {
+        message: 'Hello from get / running the default runtime',
+        routeKey: 'GET /',
+        rawPath: '/',
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: { whats: 'up' },
+        rawQueryString,
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: undefined,
+      })
+    }
+  })
+})
+
+test('[HTTP mode] get /?whats=up&whats=there', t => {
+  t.plan(15)
+  let rawQueryString = 'whats=up&whats=there'
+  tiny.get({
+    url: url + '/?' + rawQueryString
+  }, function _got (err, result) {
+    if (err) t.fail(err)
+    else {
+      checkResult(t, result.body, {
+        message: 'Hello from get / running the default runtime',
+        routeKey: 'GET /',
+        rawPath: '/',
+        pathParameters: undefined,
+        cookies: undefined,
+        queryStringParameters: { whats: 'up,there' },
+        rawQueryString,
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: undefined,
+      })
+    }
+  })
+})
+
+test('[HTTP mode] get / + cookie', t => {
+  t.plan(15)
+  let cookie = 'a=cookie'
+  tiny.get({
+    url,
+    headers: { cookie }
+  }, function _got (err, result) {
+    if (err) t.fail(err)
+    else {
+      checkResult(t, result.body, {
+        message: 'Hello from get / running the default runtime',
+        routeKey: 'GET /',
+        rawPath: '/',
+        pathParameters: undefined,
+        cookies: [ cookie ],
+        queryStringParameters: undefined,
+        rawQueryString: '',
+        headers: '🤷🏽‍♀️',
+        isBase64Encoded: false,
+        body: undefined,
+      })
+    }
+  })
+})
 
 test('[HTTP mode] get /binary', t => {
   t.plan(15)

--- a/test/integration/http/httpv1-test.js
+++ b/test/integration/http/httpv1-test.js
@@ -30,7 +30,7 @@ test('[HTTP v1.0 (REST) mode] Start Sandbox', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] get /', t => {
-  t.plan(15)
+  t.plan(16)
   tiny.get({
     url
   }, function _got (err, result) {
@@ -57,7 +57,7 @@ test('[HTTP v1.0 (REST) mode] get /', t => {
 // TODO write some cookie checks
 
 test('[HTTP v1.0 (REST) mode] get /binary', t => {
-  t.plan(16)
+  t.plan(17)
   let path = '/binary'
   tiny.get({
     url: url + path
@@ -84,7 +84,7 @@ test('[HTTP v1.0 (REST) mode] get /binary', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] get /nodejs12.x', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/nodejs12.x'
   tiny.get({
     url: url + path
@@ -109,7 +109,7 @@ test('[HTTP v1.0 (REST) mode] get /nodejs12.x', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] get /nodejs10.x', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/nodejs10.x'
   tiny.get({
     url: url + path
@@ -134,7 +134,7 @@ test('[HTTP v1.0 (REST) mode] get /nodejs10.x', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] get /nodejs8.10', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/nodejs8.10'
   tiny.get({
     url: url + path
@@ -159,7 +159,7 @@ test('[HTTP v1.0 (REST) mode] get /nodejs8.10', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] get /python3.8', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/python3.8'
   tiny.get({
     url: url + path
@@ -184,7 +184,7 @@ test('[HTTP v1.0 (REST) mode] get /python3.8', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] get /python3.7', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/python3.7'
   tiny.get({
     url: url + path
@@ -209,7 +209,7 @@ test('[HTTP v1.0 (REST) mode] get /python3.7', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] get /python3.6', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/python3.6'
   tiny.get({
     url: url + path
@@ -234,7 +234,7 @@ test('[HTTP v1.0 (REST) mode] get /python3.6', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] get /ruby2.5', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/ruby2.5'
   tiny.get({
     url: url + path
@@ -259,7 +259,7 @@ test('[HTTP v1.0 (REST) mode] get /ruby2.5', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] get /deno', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/deno'
   tiny.get({
     url: url + path
@@ -284,7 +284,7 @@ test('[HTTP v1.0 (REST) mode] get /deno', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] get /path/*', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/path/hello/there'
   tiny.get({
     url: url + path
@@ -323,7 +323,7 @@ test('[HTTP v1.0 (REST) mode] get /no-return (noop)', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] post /post', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/post'
   tiny.post({
     url: url + path,
@@ -350,7 +350,7 @@ test('[HTTP v1.0 (REST) mode] post /post', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] put /put', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/put'
   tiny.put({
     url: url + path,
@@ -376,7 +376,7 @@ test('[HTTP v1.0 (REST) mode] put /put', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] patch /patch', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/patch'
   tiny.patch({
     url: url + path,
@@ -402,7 +402,7 @@ test('[HTTP v1.0 (REST) mode] patch /patch', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] delete /delete', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/delete'
   tiny.del({
     url: url + path,
@@ -428,7 +428,7 @@ test('[HTTP v1.0 (REST) mode] delete /delete', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] head /head', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/head'
   tiny.head({
     url: url + path
@@ -453,7 +453,7 @@ test('[HTTP v1.0 (REST) mode] head /head', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] options /options', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/options'
   tiny.options({
     url: url + path
@@ -478,7 +478,7 @@ test('[HTTP v1.0 (REST) mode] options /options', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] get /any', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/any'
   tiny.get({
     url: url + path,
@@ -503,7 +503,7 @@ test('[HTTP v1.0 (REST) mode] get /any', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] post /any', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/any'
   tiny.post({
     url: url + path,
@@ -530,7 +530,7 @@ test('[HTTP v1.0 (REST) mode] post /any', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] put /any', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/any'
   tiny.put({
     url: url + path,
@@ -556,7 +556,7 @@ test('[HTTP v1.0 (REST) mode] put /any', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] patch /any', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/any'
   tiny.patch({
     url: url + path,
@@ -582,7 +582,7 @@ test('[HTTP v1.0 (REST) mode] patch /any', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] delete /any', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/any'
   tiny.del({
     url: url + path,
@@ -608,7 +608,7 @@ test('[HTTP v1.0 (REST) mode] delete /any', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] head /any', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/any'
   tiny.head({
     url: url + path,
@@ -633,7 +633,7 @@ test('[HTTP v1.0 (REST) mode] head /any', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] options /any', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/any'
   tiny.options({
     url: url + path,
@@ -658,7 +658,7 @@ test('[HTTP v1.0 (REST) mode] options /any', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] get /any-c/*', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/any-c/hello/there'
   tiny.get({
     url: url + path,
@@ -683,7 +683,7 @@ test('[HTTP v1.0 (REST) mode] get /any-c/*', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] get /any-p/:param', t => {
-  t.plan(15)
+  t.plan(16)
   let path = '/any-p/hello'
   tiny.get({
     url: url + path,

--- a/test/integration/http/httpv1-test.js
+++ b/test/integration/http/httpv1-test.js
@@ -53,8 +53,53 @@ test('[HTTP v1.0 (REST) mode] get /', t => {
   })
 })
 
-// TODO write some query string checks
-// TODO write some cookie checks
+test('[HTTP v1.0 (REST) mode] get /?whats=up', t => {
+  t.plan(16)
+  tiny.get({
+    url: url + '/?whats=up'
+  }, function _got (err, result) {
+    if (err) t.fail(err)
+    else {
+      checkResult(t, result.body, {
+        message: 'Hello from get / running the default runtime',
+        resource: '/',
+        path: '/',
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: { whats: 'up' },
+        multiValueQueryStringParameters: { whats: [ 'up' ] },
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
+    }
+  })
+})
+
+test('[HTTP v1.0 (REST) mode] get /?whats=up&whats=there', t => {
+  t.plan(16)
+  tiny.get({
+    url: url + '/?whats=up&whats=there'
+  }, function _got (err, result) {
+    if (err) t.fail(err)
+    else {
+      checkResult(t, result.body, {
+        message: 'Hello from get / running the default runtime',
+        resource: '/',
+        path: '/',
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: { whats: 'there' },
+        multiValueQueryStringParameters: { whats: [ 'up', 'there' ] },
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
+    }
+  })
+})
 
 test('[HTTP v1.0 (REST) mode] get /binary', t => {
   t.plan(17)

--- a/test/integration/http/httpv1-test.js
+++ b/test/integration/http/httpv1-test.js
@@ -19,7 +19,7 @@ test('Set up env', t => {
 test('[HTTP v1.0 (REST) mode] Start Sandbox', t => {
   t.plan(4)
   process.chdir(join(mock, 'normal'))
-  sandbox.start({}, function (err, result) {
+  sandbox.start({ quiet: true }, function (err, result) {
     if (err) t.fail(err)
     else {
       t.notOk(process.env.DEPRECATED, 'Arc v5 deprecated status NOT set')
@@ -523,7 +523,7 @@ test('[HTTP v1.0 (REST) mode] Shut down Sandbox', t => {
 test('[HTTP v1.0 (REST) mode] Start Sandbox', t => {
   t.plan(3)
   process.chdir(join(mock, 'no-index-fail'))
-  sandbox.start({}, function (err, result) {
+  sandbox.start({ quiet: true }, function (err, result) {
     if (err) t.fail(err)
     else {
       t.notOk(process.env.DEPRECATED, 'Arc v5 deprecated status NOT set')
@@ -554,7 +554,7 @@ test('[HTTP v1.0 (REST) mode] Shut down Sandbox', t => {
 test('[HTTP v1.0 (REST) mode] Start Sandbox', t => {
   t.plan(3)
   process.chdir(join(mock, 'no-index-pass'))
-  sandbox.start({}, function (err, result) {
+  sandbox.start({ quiet: true }, function (err, result) {
     if (err) t.fail(err)
     else {
       t.notOk(process.env.DEPRECATED, 'Arc v5 deprecated status NOT set')
@@ -589,7 +589,7 @@ test('[HTTP v1.0 (REST) mode] Shut down Sandbox', t => {
 test('[HTTP v1.0 (REST) mode] Start Sandbox', t => {
   t.plan(1)
   process.chdir(join(mock, 'no-http'))
-  sandbox.start({}, function (err, result) {
+  sandbox.start({ quiet: true }, function (err, result) {
     if (err) t.fail(err)
     else t.equal(result, 'Sandbox successfully started', 'Sandbox started')
   })

--- a/test/integration/http/httpv1-test.js
+++ b/test/integration/http/httpv1-test.js
@@ -3,12 +3,11 @@ let tiny = require('tiny-json-http')
 let test = require('tape')
 let sut = join(process.cwd(), 'src')
 let sandbox = require(sut)
-let { url, shutdown } = require('./_utils')
+let { url, data, shutdown, checkRestResult: checkResult } = require('./_utils')
 
 let cwd = process.cwd()
 let mock = join(__dirname, '..', '..', 'mock')
 let b64dec = i => Buffer.from(i, 'base64').toString()
-let data = { hi: 'there' }
 
 test('Set up env', t => {
   t.plan(1)
@@ -31,172 +30,280 @@ test('[HTTP v1.0 (REST) mode] Start Sandbox', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] get /', t => {
-  t.plan(3)
+  t.plan(15)
   tiny.get({
     url
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /')
-      let { message, version } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(message, 'Hello from get / running the default runtime', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get / running the default runtime',
+        resource: '/',
+        path: '/',
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
+// TODO write some query string checks
+// TODO write some cookie checks
+
 test('[HTTP v1.0 (REST) mode] get /binary', t => {
-  t.plan(3)
+  t.plan(16)
+  let path = '/binary'
   tiny.get({
-    url: url + '/binary'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
+      checkResult(t, JSON.parse(result.headers.body), {
+        message: 'Hello from get /binary',
+        resource: path,
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
       const img = Buffer.from(result.body).toString('base64')
-      t.ok(result, 'got /binary')
-      let { version } = JSON.parse(result.headers.body)
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
       t.ok(img.includes('AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAA'), 'is binary')
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] get /nodejs12.x', t => {
-  t.plan(3)
+  t.plan(15)
+  let path = '/nodejs12.x'
   tiny.get({
-    url: url + '/nodejs12.x'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /nodejs12.x')
-      let { message, version } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(message, 'Hello from get /nodejs12.x (running nodejs12.x)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /nodejs12.x (running nodejs12.x)',
+        resource: path,
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] get /nodejs10.x', t => {
-  t.plan(3)
+  t.plan(15)
+  let path = '/nodejs10.x'
   tiny.get({
-    url: url + '/nodejs10.x'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /nodejs10.x')
-      let { message, version } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(message, 'Hello from get /nodejs10.x (running nodejs10.x)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /nodejs10.x (running nodejs10.x)',
+        resource: path,
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] get /nodejs8.10', t => {
-  t.plan(3)
+  t.plan(15)
+  let path = '/nodejs8.10'
   tiny.get({
-    url: url + '/nodejs8.10'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /nodejs8.10')
-      let { message, version } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(message, 'Hello from get /nodejs8.10 (running nodejs8.10)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /nodejs8.10 (running nodejs8.10)',
+        resource: path,
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] get /python3.8', t => {
-  t.plan(3)
+  t.plan(15)
+  let path = '/python3.8'
   tiny.get({
-    url: url + '/python3.8'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /python3.8')
-      let { message, version } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(message, 'Hello from get /python3.8 (running python3.8)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /python3.8 (running python3.8)',
+        resource: path,
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] get /python3.7', t => {
-  t.plan(3)
+  t.plan(15)
+  let path = '/python3.7'
   tiny.get({
-    url: url + '/python3.7'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /python3.7')
-      let { message, version } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(message, 'Hello from get /python3.7 (running python3.7)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /python3.7 (running python3.7)',
+        resource: path,
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] get /python3.6', t => {
-  t.plan(3)
+  t.plan(15)
+  let path = '/python3.6'
   tiny.get({
-    url: url + '/python3.6'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /python3.6')
-      let { message, version } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(message, 'Hello from get /python3.6 (running python3.6)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /python3.6 (running python3.6)',
+        resource: path,
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] get /ruby2.5', t => {
-  t.plan(3)
+  t.plan(15)
+  let path = '/ruby2.5'
   tiny.get({
-    url: url + '/ruby2.5'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /ruby2.5')
-      let { message, version } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(message, 'Hello from Architect Sandbox running ruby2.5!', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from Architect Sandbox running ruby2.5!',
+        resource: path,
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] get /deno', t => {
-  t.plan(3)
+  t.plan(15)
+  let path = '/deno'
   tiny.get({
-    url: url + '/deno'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /deno')
-      let { message, version } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(message, 'Hello from Architect Sandbox running deno!', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from Architect Sandbox running deno!',
+        resource: path,
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] get /path/*', t => {
-  t.plan(8)
+  t.plan(15)
+  let path = '/path/hello/there'
   tiny.get({
-    url: url + '/path/hello/there'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /path/*')
-      let { message, version, resource, path, pathParameters, requestContext } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(message, 'Hello from get /path/* running the default runtime')
-      t.equal(resource, '/path/{proxy+}', 'Got correct resource param')
-      t.equal(path, '/path/hello/there', 'Got correct path param')
-      t.equal(pathParameters.proxy, 'hello/there', 'Got correct pathParameters.proxy')
-      t.equal(requestContext.path, '/path/hello/there', 'Got correct requestContext.path param')
-      t.equal(requestContext.resourcePath, '/path/{proxy+}', 'Got correct requestContext.resourcePath param')
+      checkResult(t, result.body, {
+        message: 'Hello from get /path/* running the default runtime',
+        resource: '/path/{proxy+}',
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: { proxy: 'hello/there' },
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
@@ -216,266 +323,386 @@ test('[HTTP v1.0 (REST) mode] get /no-return (noop)', t => {
 })
 
 test('[HTTP v1.0 (REST) mode] post /post', t => {
-  t.plan(5)
+  t.plan(15)
+  let path = '/post'
   tiny.post({
-    url: url + '/post',
+    url: url + path,
     data,
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'posted /post')
-      let { body, message, isBase64Encoded, version } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(message, 'Hello from post /post', 'Got correct handler response')
-      t.equal(b64dec(body), 'hi=there', 'Got base64-encoded form URL-encoded body payload')
-      t.ok(isBase64Encoded, 'Got isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from post /post',
+        resource: path,
+        path,
+        httpMethod: 'POST',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        isBase64Encoded: true,
+      })
+      t.equal(b64dec(result.body.body), 'hi=there', 'Got base64-encoded form URL-encoded body payload')
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] put /put', t => {
-  t.plan(5)
+  t.plan(15)
+  let path = '/put'
   tiny.put({
-    url: url + '/put',
+    url: url + path,
     data,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'put /put')
-      let { body, message, isBase64Encoded, version } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(message, 'Hello from put /put', 'Got correct handler response')
-      t.equal(b64dec(body), JSON.stringify(data), 'Got base64-encoded JSON-serialized body payload')
-      t.ok(isBase64Encoded, 'Got isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from put /put',
+        resource: path,
+        path,
+        httpMethod: 'PUT',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: true,
+        isBase64Encoded: true,
+      })
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] patch /patch', t => {
-  t.plan(5)
+  t.plan(15)
+  let path = '/patch'
   tiny.patch({
-    url: url + '/patch',
+    url: url + path,
     data,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'patched /patch')
-      let { body, message, isBase64Encoded, version } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(message, 'Hello from patch /patch', 'Got correct handler response')
-      t.equal(b64dec(body), JSON.stringify(data), 'Got base64-encoded JSON-serialized body payload')
-      t.ok(isBase64Encoded, 'Got isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from patch /patch',
+        resource: path,
+        path,
+        httpMethod: 'PATCH',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: true,
+        isBase64Encoded: true,
+      })
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] delete /delete', t => {
-  t.plan(5)
+  t.plan(15)
+  let path = '/delete'
   tiny.del({
-    url: url + '/delete',
+    url: url + path,
     data,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'deleted /delete')
-      let { body, message, isBase64Encoded, version } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(message, 'Hello from delete /delete', 'Got correct handler response')
-      t.equal(b64dec(body), JSON.stringify(data), 'Got base64-encoded JSON-serialized body payload')
-      t.ok(isBase64Encoded, 'Got isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from delete /delete',
+        resource: path,
+        path,
+        httpMethod: 'DELETE',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: true,
+        isBase64Encoded: true,
+      })
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] head /head', t => {
-  t.plan(3)
+  t.plan(15)
+  let path = '/head'
   tiny.head({
-    url: url + '/head'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'headed /head')
-      let { message, version } = JSON.parse(result.headers.body)
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(message, 'Hello from head /head', 'Got correct handler response')
+      checkResult(t, JSON.parse(result.headers.body), {
+        message: 'Hello from head /head',
+        resource: path,
+        path,
+        httpMethod: 'HEAD',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] options /options', t => {
-  t.plan(3)
+  t.plan(15)
+  let path = '/options'
   tiny.options({
-    url: url + '/options'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'optioned /options')
-      let { message, version } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(message, 'Hello from options /options', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from options /options',
+        resource: path,
+        path,
+        httpMethod: 'OPTIONS',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] get /any', t => {
-  t.plan(4)
+  t.plan(15)
+  let path = '/any'
   tiny.get({
-    url: url + '/any',
+    url: url + path,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /any')
-      let { message, version, httpMethod } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(httpMethod, 'GET', 'Got correct method')
-      t.equal(message, 'Hello from any /any', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from any /any',
+        resource: path,
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] post /any', t => {
-  t.plan(6)
+  t.plan(15)
+  let path = '/any'
   tiny.post({
-    url: url + '/any',
+    url: url + path,
     data,
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'posted /any')
-      let { body, message, isBase64Encoded, version, httpMethod } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(httpMethod, 'POST', 'Got correct method')
-      t.equal(message, 'Hello from any /any', 'Got correct handler response')
-      t.equal(b64dec(body), 'hi=there', 'Got base64-encoded form URL-encoded body payload')
-      t.ok(isBase64Encoded, 'Got isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from any /any',
+        resource: path,
+        path,
+        httpMethod: 'POST',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        isBase64Encoded: true,
+      })
+      t.equal(b64dec(result.body.body), 'hi=there', 'Got base64-encoded form URL-encoded body payload')
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] put /any', t => {
-  t.plan(6)
+  t.plan(15)
+  let path = '/any'
   tiny.put({
-    url: url + '/any',
+    url: url + path,
     data,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'put /any')
-      let { body, message, isBase64Encoded, version, httpMethod } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(httpMethod, 'PUT', 'Got correct method')
-      t.equal(message, 'Hello from any /any', 'Got correct handler response')
-      t.equal(b64dec(body), JSON.stringify(data), 'Got base64-encoded JSON-serialized body payload')
-      t.ok(isBase64Encoded, 'Got isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from any /any',
+        resource: path,
+        path,
+        httpMethod: 'PUT',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: true,
+        isBase64Encoded: true,
+      })
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] patch /any', t => {
-  t.plan(6)
+  t.plan(15)
+  let path = '/any'
   tiny.patch({
-    url: url + '/any',
+    url: url + path,
     data,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'patched /any')
-      let { body, message, isBase64Encoded, version, httpMethod } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(httpMethod, 'PATCH', 'Got correct method')
-      t.equal(message, 'Hello from any /any', 'Got correct handler response')
-      t.equal(b64dec(body), JSON.stringify(data), 'Got base64-encoded JSON-serialized body payload')
-      t.ok(isBase64Encoded, 'Got isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from any /any',
+        resource: path,
+        path,
+        httpMethod: 'PATCH',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: true,
+        isBase64Encoded: true,
+      })
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] delete /any', t => {
-  t.plan(6)
+  t.plan(15)
+  let path = '/any'
   tiny.del({
-    url: url + '/any',
+    url: url + path,
     data,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'deleted /any')
-      let { body, message, isBase64Encoded, version, httpMethod } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(httpMethod, 'DELETE', 'Got correct method')
-      t.equal(message, 'Hello from any /any', 'Got correct handler response')
-      t.equal(b64dec(body), JSON.stringify(data), 'Got base64-encoded JSON-serialized body payload')
-      t.ok(isBase64Encoded, 'Got isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from any /any',
+        resource: path,
+        path,
+        httpMethod: 'DELETE',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: true,
+        isBase64Encoded: true,
+      })
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] head /any', t => {
-  t.plan(4)
+  t.plan(15)
+  let path = '/any'
   tiny.head({
-    url: url + '/any',
+    url: url + path,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'headed /any')
-      let { message, version, httpMethod } = JSON.parse(result.headers.body)
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(httpMethod, 'HEAD', 'Got correct method')
-      t.equal(message, 'Hello from any /any', 'Got correct handler response')
+      checkResult(t, JSON.parse(result.headers.body), {
+        message: 'Hello from any /any',
+        resource: path,
+        path,
+        httpMethod: 'HEAD',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] options /any', t => {
-  t.plan(4)
+  t.plan(15)
+  let path = '/any'
   tiny.options({
-    url: url + '/any',
+    url: url + path,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'optioned /any')
-      let { message, version, httpMethod } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(httpMethod, 'OPTIONS', 'Got correct method')
-      t.equal(message, 'Hello from any /any', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from any /any',
+        resource: path,
+        path,
+        httpMethod: 'OPTIONS',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] get /any-c/*', t => {
-  t.plan(9)
+  t.plan(15)
+  let path = '/any-c/hello/there'
   tiny.get({
-    url: url + '/any-c/hello/there',
+    url: url + path,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /any-c/hello/there')
-      let { message, version, httpMethod, resource, path, pathParameters, requestContext } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(httpMethod, 'GET', 'Got correct method')
-      t.equal(message, 'Hello from any /any-c/*', 'Got correct handler response')
-      t.equal(resource, '/any-c/{proxy+}', 'Got correct resource param')
-      t.equal(path, '/any-c/hello/there', 'Got correct path param')
-      t.equal(pathParameters.proxy, 'hello/there', 'Got correct pathParameters.proxy')
-      t.equal(requestContext.path, '/any-c/hello/there', 'Got correct requestContext.path param')
-      t.equal(requestContext.resourcePath, '/any-c/{proxy+}', 'Got correct requestContext.resourcePath param')
+      checkResult(t, result.body, {
+        message: 'Hello from any /any-c/*',
+        resource: '/any-c/{proxy+}',
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: { proxy: 'hello/there' },
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[HTTP v1.0 (REST) mode] get /any-p/:param', t => {
-  t.plan(4)
+  t.plan(15)
+  let path = '/any-p/hello'
   tiny.get({
-    url: url + '/any-p/hello',
+    url: url + path,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /any-p/hello')
-      let { message, version, httpMethod } = result.body
-      t.equal(version, '1.0', 'Got Lambda v1.0 payload')
-      t.equal(httpMethod, 'GET', 'Got correct method')
-      t.equal(message, 'Hello from any /any-p/:param', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from any /any-p/:param',
+        resource: '/any-p/{param}',
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: { param: 'hello' },
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })

--- a/test/integration/http/httpv1-test.js
+++ b/test/integration/http/httpv1-test.js
@@ -1,10 +1,12 @@
-let path = require('path')
+let { join } = require('path')
 let tiny = require('tiny-json-http')
 let test = require('tape')
-let sandbox = require('../../../src')
+let sut = join(process.cwd(), 'src')
+let sandbox = require(sut)
 let { url, shutdown } = require('./_utils')
 
 let cwd = process.cwd()
+let mock = join(__dirname, '..', '..', 'mock')
 let b64dec = i => Buffer.from(i, 'base64').toString()
 let data = { hi: 'there' }
 
@@ -16,7 +18,7 @@ test('Set up env', t => {
 
 test('[HTTP v1.0 (REST) mode] Start Sandbox', t => {
   t.plan(4)
-  process.chdir(path.join(__dirname, '..', '..', 'mock', 'normal'))
+  process.chdir(join(mock, 'normal'))
   sandbox.start({}, function (err, result) {
     if (err) t.fail(err)
     else {
@@ -520,7 +522,7 @@ test('[HTTP v1.0 (REST) mode] Shut down Sandbox', t => {
  */
 test('[HTTP v1.0 (REST) mode] Start Sandbox', t => {
   t.plan(3)
-  process.chdir(path.join(__dirname, '..', '..', 'mock', 'no-index-fail'))
+  process.chdir(join(mock, 'no-index-fail'))
   sandbox.start({}, function (err, result) {
     if (err) t.fail(err)
     else {
@@ -551,7 +553,7 @@ test('[HTTP v1.0 (REST) mode] Shut down Sandbox', t => {
  */
 test('[HTTP v1.0 (REST) mode] Start Sandbox', t => {
   t.plan(3)
-  process.chdir(path.join(__dirname, '..', '..', 'mock', 'no-index-pass'))
+  process.chdir(join(mock, 'no-index-pass'))
   sandbox.start({}, function (err, result) {
     if (err) t.fail(err)
     else {
@@ -586,7 +588,7 @@ test('[HTTP v1.0 (REST) mode] Shut down Sandbox', t => {
  */
 test('[HTTP v1.0 (REST) mode] Start Sandbox', t => {
   t.plan(1)
-  process.chdir(path.join(__dirname, '..', '..', 'mock', 'no-http'))
+  process.chdir(join(mock, 'no-http'))
   sandbox.start({}, function (err, result) {
     if (err) t.fail(err)
     else t.equal(result, 'Sandbox successfully started', 'Sandbox started')

--- a/test/integration/http/httpv1-test.js
+++ b/test/integration/http/httpv1-test.js
@@ -478,6 +478,9 @@ test('[HTTP v1.0 (REST) mode] get /any-p/:param', t => {
   })
 })
 
+/**
+ * Arc v8+: routes are now literal, no more greedy root (`any /{proxy+}`) fallthrough
+ */
 test('[HTTP v1.0 (REST) mode] post / - route should fail when not explicitly defined', t => {
   t.plan(2)
   tiny.post({

--- a/test/integration/http/httpv1-test.js
+++ b/test/integration/http/httpv1-test.js
@@ -54,7 +54,7 @@ test('[HTTP v1.0 (REST) mode] get /binary', t => {
     else {
       const img = Buffer.from(result.body).toString('base64')
       t.ok(result, 'got /binary')
-      let { version } = result.headers
+      let { version } = JSON.parse(result.headers.body)
       t.equal(version, '1.0', 'Got Lambda v1.0 payload')
       t.ok(img.includes('AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAA'), 'is binary')
     }

--- a/test/integration/http/misc-test.js
+++ b/test/integration/http/misc-test.js
@@ -1,10 +1,12 @@
-let path = require('path')
+let { join } = require('path')
 let tiny = require('tiny-json-http')
 let test = require('tape')
-let sandbox = require('../../../src')
+let sut = join(process.cwd(), 'src')
+let sandbox = require(sut)
 let { url, shutdown } = require('./_utils')
 
 let cwd = process.cwd()
+let mock = join(__dirname, '..', '..', 'mock')
 
 test('Set up env', t => {
   t.plan(1)
@@ -13,7 +15,7 @@ test('Set up env', t => {
 
 test('[Misc] Start Sandbox', t => {
   t.plan(4)
-  process.chdir(path.join(__dirname, '..', '..', 'mock', 'normal'))
+  process.chdir(join(mock, 'normal'))
   sandbox.start({}, function (err, result) {
     if (err) t.fail(err)
     else {

--- a/test/integration/http/misc-test.js
+++ b/test/integration/http/misc-test.js
@@ -16,7 +16,7 @@ test('Set up env', t => {
 test('[Misc] Start Sandbox', t => {
   t.plan(4)
   process.chdir(join(mock, 'normal'))
-  sandbox.start({}, function (err, result) {
+  sandbox.start({ quiet: true }, function (err, result) {
     if (err) t.fail(err)
     else {
       t.notOk(process.env.DEPRECATED, 'Arc v5 deprecated status NOT set')

--- a/test/integration/http/module-test.js
+++ b/test/integration/http/module-test.js
@@ -20,7 +20,7 @@ test('Set up env', t => {
 test('Sync http.start', t => {
   t.plan(3)
   process.chdir(join(mock, 'normal'))
-  http.start({}, function (err, result) {
+  http.start({ quiet: true }, function (err, result) {
     if (err) t.fail(err)
     t.equal(process.env.ARC_API_TYPE, 'http', 'API type set to http')
     t.notOk(process.env.DEPRECATED, 'Arc v5 deprecated status NOT set')
@@ -74,7 +74,7 @@ test('Async http.start', async t => {
   t.plan(3)
   process.chdir(join(mock, 'normal'))
   try {
-    let result = await http.start({})
+    let result = await http.start({ quiet: true })
     t.equal(result, 'HTTP successfully started', 'Sandbox started')
     t.equal(process.env.ARC_API_TYPE, 'http', 'API type set to http')
     t.notOk(process.env.DEPRECATED, 'Arc v5 deprecated status NOT set')

--- a/test/integration/http/module-test.js
+++ b/test/integration/http/module-test.js
@@ -1,9 +1,11 @@
-let path = require('path')
+let { join } = require('path')
 let tiny = require('tiny-json-http')
 let test = require('tape')
-let { http } = require('../../../src')
+let sut = join(process.cwd(), 'src')
+let { http } = require(sut)
 let { url, verifyShutdown } = require('./_utils')
 let cwd = process.cwd()
+let mock = join(__dirname, '..', '..', 'mock')
 
 test('Set up env', t => {
   t.plan(1)
@@ -17,7 +19,7 @@ test('Set up env', t => {
  */
 test('Sync http.start', t => {
   t.plan(3)
-  process.chdir(path.join(__dirname, '..', '..', 'mock', 'normal'))
+  process.chdir(join(mock, 'normal'))
   http.start({}, function (err, result) {
     if (err) t.fail(err)
     t.equal(process.env.ARC_API_TYPE, 'http', 'API type set to http')
@@ -70,7 +72,7 @@ test('Sync http.end', t => {
 
 test('Async http.start', async t => {
   t.plan(3)
-  process.chdir(path.join(__dirname, '..', '..', 'mock', 'normal'))
+  process.chdir(join(mock, 'normal'))
   try {
     let result = await http.start({})
     t.equal(result, 'HTTP successfully started', 'Sandbox started')

--- a/test/integration/http/rest-test.js
+++ b/test/integration/http/rest-test.js
@@ -286,46 +286,61 @@ test('[REST mode] post / - route should fail when not explicitly defined, but on
 })
 
 test('[REST mode] get /foobar – route should fall through to greedy root', t => {
-  t.plan(3)
+  t.plan(8)
   tiny.get({
     url: url + '/foobar',
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
       t.ok(result, 'got /')
-      let { message, version } = result.body
+      let { message, version, resource, path, pathParameters, requestContext } = result.body
       t.notOk(version, 'No Lambda payload version specified')
       t.equal(message, 'Hello from get / running the default runtime', 'Got correct handler response')
+      t.equal(resource, '/{proxy+}', 'Got correct resource param')
+      t.equal(path, '/foobar', 'Got correct path param')
+      t.equal(pathParameters.proxy, 'foobar', 'Got correct pathParameters.proxy')
+      t.equal(requestContext.path, '/foobar', 'Got correct requestContext.path param')
+      t.equal(requestContext.resourcePath, '/{proxy+}', 'Got correct requestContext.resourcePath param')
     }
   })
 })
 
 test('[REST mode] get /path/* – route should fall through to greedy root because catchalls are not supported in this mode', t => {
-  t.plan(3)
+  t.plan(8)
   tiny.get({
     url: url + '/path/hello/there'
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
       t.ok(result, 'got /')
-      let { message, version } = result.body
+      let { message, version, resource, path, pathParameters, requestContext } = result.body
       t.notOk(version, 'No Lambda payload version specified')
       t.equal(message, 'Hello from get / running the default runtime', 'Got correct handler response')
+      t.equal(resource, '/{proxy+}', 'Got correct resource param')
+      t.equal(path, '/path/hello/there', 'Got correct path param')
+      t.equal(pathParameters.proxy, 'path/hello/there', 'Got correct pathParameters.proxy')
+      t.equal(requestContext.path, '/path/hello/there', 'Got correct requestContext.path param')
+      t.equal(requestContext.resourcePath, '/{proxy+}', 'Got correct requestContext.resourcePath param')
     }
   })
 })
 
 test(`[REST mode] get /any – route should fall through to greedy root because 'any' is not supported in this mode`, t => {
-  t.plan(3)
+  t.plan(8)
   tiny.get({
     url: url + '/any'
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
       t.ok(result, 'got /')
-      let { message, version } = result.body
+      let { message, version, resource, path, pathParameters, requestContext } = result.body
       t.notOk(version, 'No Lambda payload version specified')
       t.equal(message, 'Hello from get / running the default runtime', 'Got correct handler response')
+      t.equal(resource, '/{proxy+}', 'Got correct resource param')
+      t.equal(path, '/any', 'Got correct path param')
+      t.equal(pathParameters.proxy, 'any', 'Got correct pathParameters.proxy')
+      t.equal(requestContext.path, '/any', 'Got correct requestContext.path param')
+      t.equal(requestContext.resourcePath, '/{proxy+}', 'Got correct requestContext.resourcePath param')
     }
   })
 })

--- a/test/integration/http/rest-test.js
+++ b/test/integration/http/rest-test.js
@@ -53,8 +53,53 @@ test('[REST mode] get /', t => {
   })
 })
 
-// TODO write some query string checks
-// TODO write some cookie checks
+test('[REST mode] get /?whats=up', t => {
+  t.plan(16)
+  tiny.get({
+    url: url + '/?whats=up'
+  }, function _got (err, result) {
+    if (err) t.fail(err)
+    else {
+      checkResult(t, result.body, {
+        message: 'Hello from get / running the default runtime',
+        resource: '/',
+        path: '/',
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: { whats: 'up' },
+        multiValueQueryStringParameters: { whats: [ 'up' ] },
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
+    }
+  })
+})
+
+test('[REST mode] get /?whats=up&whats=there', t => {
+  t.plan(16)
+  tiny.get({
+    url: url + '/?whats=up&whats=there'
+  }, function _got (err, result) {
+    if (err) t.fail(err)
+    else {
+      checkResult(t, result.body, {
+        message: 'Hello from get / running the default runtime',
+        resource: '/',
+        path: '/',
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: { whats: 'there' },
+        multiValueQueryStringParameters: { whats: [ 'up', 'there' ] },
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
+    }
+  })
+})
 
 test('[REST mode] get /binary', t => {
   t.plan(17)

--- a/test/integration/http/rest-test.js
+++ b/test/integration/http/rest-test.js
@@ -19,7 +19,7 @@ test('Set up env', t => {
 test('[REST mode] Start Sandbox', t => {
   t.plan(4)
   process.chdir(join(mock, 'normal'))
-  sandbox.start({}, function (err, result) {
+  sandbox.start({ quiet: true }, function (err, result) {
     if (err) t.fail(err)
     else {
       t.notOk(process.env.DEPRECATED, 'Arc v5 deprecated status NOT set')
@@ -358,7 +358,7 @@ test('[REST mode] Shut down Sandbox', t => {
 test('[REST mode] Start Sandbox', t => {
   t.plan(3)
   process.chdir(join(mock, 'no-index-fail'))
-  sandbox.start({}, function (err, result) {
+  sandbox.start({ quiet: true }, function (err, result) {
     if (err) t.fail(err)
     else {
       t.notOk(process.env.DEPRECATED, 'Arc v5 deprecated status NOT set')
@@ -389,7 +389,7 @@ test('[REST mode] Shut down Sandbox', t => {
 test('[REST mode] Start Sandbox', t => {
   t.plan(3)
   process.chdir(join(mock, 'no-index-pass'))
-  sandbox.start({}, function (err, result) {
+  sandbox.start({ quiet: true }, function (err, result) {
     if (err) t.fail(err)
     else {
       t.notOk(process.env.DEPRECATED, 'Arc v5 deprecated status NOT set')
@@ -424,7 +424,7 @@ test('[REST mode] Shut down Sandbox', t => {
 test('[REST mode] Start Sandbox', t => {
   t.plan(1)
   process.chdir(join(mock, 'no-http'))
-  sandbox.start({}, function (err, result) {
+  sandbox.start({ quiet: true }, function (err, result) {
     if (err) t.fail(err)
     else {
       t.equal(result, 'Sandbox successfully started', 'Sandbox started')

--- a/test/integration/http/rest-test.js
+++ b/test/integration/http/rest-test.js
@@ -1,10 +1,12 @@
-let path = require('path')
+let { join } = require('path')
 let tiny = require('tiny-json-http')
 let test = require('tape')
-let sandbox = require('../../../src')
+let sut = join(process.cwd(), 'src')
+let sandbox = require(sut)
 let { url, shutdown } = require('./_utils')
 
 let cwd = process.cwd()
+let mock = join(__dirname, '..', '..', 'mock')
 let b64dec = i => Buffer.from(i, 'base64').toString()
 let data = { hi: 'there' }
 
@@ -16,7 +18,7 @@ test('Set up env', t => {
 
 test('[REST mode] Start Sandbox', t => {
   t.plan(4)
-  process.chdir(path.join(__dirname, '..', '..', 'mock', 'normal'))
+  process.chdir(join(mock, 'normal'))
   sandbox.start({}, function (err, result) {
     if (err) t.fail(err)
     else {
@@ -355,7 +357,7 @@ test('[REST mode] Shut down Sandbox', t => {
  */
 test('[REST mode] Start Sandbox', t => {
   t.plan(3)
-  process.chdir(path.join(__dirname, '..', '..', 'mock', 'no-index-fail'))
+  process.chdir(join(mock, 'no-index-fail'))
   sandbox.start({}, function (err, result) {
     if (err) t.fail(err)
     else {
@@ -386,7 +388,7 @@ test('[REST mode] Shut down Sandbox', t => {
  */
 test('[REST mode] Start Sandbox', t => {
   t.plan(3)
-  process.chdir(path.join(__dirname, '..', '..', 'mock', 'no-index-pass'))
+  process.chdir(join(mock, 'no-index-pass'))
   sandbox.start({}, function (err, result) {
     if (err) t.fail(err)
     else {
@@ -421,7 +423,7 @@ test('[REST mode] Shut down Sandbox', t => {
  */
 test('[REST mode] Start Sandbox', t => {
   t.plan(1)
-  process.chdir(path.join(__dirname, '..', '..', 'mock', 'no-http'))
+  process.chdir(join(mock, 'no-http'))
   sandbox.start({}, function (err, result) {
     if (err) t.fail(err)
     else {

--- a/test/integration/http/rest-test.js
+++ b/test/integration/http/rest-test.js
@@ -54,7 +54,7 @@ test('[REST mode] get /binary', t => {
     else {
       const img = Buffer.from(result.body).toString('base64')
       t.ok(result, 'got /binary')
-      let { version } = result.headers
+      let { version } = JSON.parse(result.headers.body)
       t.notOk(version, 'No Lambda payload version specified')
       t.ok(img.includes('AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAA'), 'is binary')
     }

--- a/test/integration/http/rest-test.js
+++ b/test/integration/http/rest-test.js
@@ -3,12 +3,11 @@ let tiny = require('tiny-json-http')
 let test = require('tape')
 let sut = join(process.cwd(), 'src')
 let sandbox = require(sut)
-let { url, shutdown } = require('./_utils')
+let { url, data, shutdown, checkRestResult: checkResult } = require('./_utils')
 
 let cwd = process.cwd()
 let mock = join(__dirname, '..', '..', 'mock')
 let b64dec = i => Buffer.from(i, 'base64').toString()
-let data = { hi: 'there' }
 
 test('Set up env', t => {
   t.plan(1)
@@ -31,152 +30,255 @@ test('[REST mode] Start Sandbox', t => {
 })
 
 test('[REST mode] get /', t => {
-  t.plan(3)
+  t.plan(16)
   tiny.get({
     url
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /')
-      let { message, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from get / running the default runtime', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get / running the default runtime',
+        resource: '/',
+        path: '/',
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
+// TODO write some query string checks
+// TODO write some cookie checks
+
 test('[REST mode] get /binary', t => {
-  t.plan(3)
+  t.plan(17)
+  let path = '/binary'
   tiny.get({
-    url: url + '/binary'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
+      checkResult(t, JSON.parse(result.headers.body), {
+        message: 'Hello from get /binary',
+        resource: path,
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
       const img = Buffer.from(result.body).toString('base64')
-      t.ok(result, 'got /binary')
-      let { version } = JSON.parse(result.headers.body)
-      t.notOk(version, 'No Lambda payload version specified')
       t.ok(img.includes('AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAA'), 'is binary')
     }
   })
 })
 
 test('[REST mode] get /nodejs12.x', t => {
-  t.plan(3)
+  t.plan(16)
+  let path = '/nodejs12.x'
   tiny.get({
-    url: url + '/nodejs12.x'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /nodejs12.x')
-      let { message, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from get /nodejs12.x (running nodejs12.x)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /nodejs12.x (running nodejs12.x)',
+        resource: path,
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[REST mode] get /nodejs10.x', t => {
-  t.plan(3)
+  t.plan(16)
+  let path = '/nodejs10.x'
   tiny.get({
-    url: url + '/nodejs10.x'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /nodejs10.x')
-      let { message, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from get /nodejs10.x (running nodejs10.x)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /nodejs10.x (running nodejs10.x)',
+        resource: path,
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[REST mode] get /nodejs8.10', t => {
-  t.plan(3)
+  t.plan(16)
+  let path = '/nodejs8.10'
   tiny.get({
-    url: url + '/nodejs8.10'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /nodejs8.10')
-      let { message, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from get /nodejs8.10 (running nodejs8.10)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /nodejs8.10 (running nodejs8.10)',
+        resource: path,
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[REST mode] get /python3.8', t => {
-  t.plan(3)
+  t.plan(16)
+  let path = '/python3.8'
   tiny.get({
-    url: url + '/python3.8'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /python3.8')
-      let { message, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from get /python3.8 (running python3.8)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /python3.8 (running python3.8)',
+        resource: path,
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[REST mode] get /python3.7', t => {
-  t.plan(3)
+  t.plan(16)
+  let path = '/python3.7'
   tiny.get({
-    url: url + '/python3.7'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /python3.7')
-      let { message, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from get /python3.7 (running python3.7)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /python3.7 (running python3.7)',
+        resource: path,
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[REST mode] get /python3.6', t => {
-  t.plan(3)
+  t.plan(16)
+  let path = '/python3.6'
   tiny.get({
-    url: url + '/python3.6'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /python3.6')
-      let { message, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from get /python3.6 (running python3.6)', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from get /python3.6 (running python3.6)',
+        resource: path,
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[REST mode] get /ruby2.5', t => {
-  t.plan(3)
+  t.plan(16)
+  let path = '/ruby2.5'
   tiny.get({
-    url: url + '/ruby2.5'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /ruby2.5')
-      let { message, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from Architect Sandbox running ruby2.5!', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from Architect Sandbox running ruby2.5!',
+        resource: path,
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[REST mode] get /deno', t => {
-  t.plan(3)
+  t.plan(16)
+  let path = '/deno'
   tiny.get({
-    url: url + '/deno'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /deno')
-      let { message, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from Architect Sandbox running deno!', 'Got correct handler response')
+      checkResult(t, result.body, {
+        message: 'Hello from Architect Sandbox running deno!',
+        resource: path,
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
@@ -196,74 +298,107 @@ test('[REST mode] get /no-return (noop)', t => {
 })
 
 test('[REST mode] post /post', t => {
-  t.plan(5)
+  t.plan(16)
+  let path = '/post'
   tiny.post({
-    url: url + '/post',
+    url: url + path,
     data,
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'posted /post')
-      let { body, message, isBase64Encoded, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from post /post', 'Got correct handler response')
-      t.equal(b64dec(body), 'hi=there', 'Got base64-encoded form URL-encoded body payload')
-      t.ok(isBase64Encoded, 'Got isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from post /post',
+        resource: path,
+        path,
+        httpMethod: 'POST',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        // body: true,
+        isBase64Encoded: true,
+      })
+      t.equal(b64dec(result.body.body), 'hi=there', 'Got base64-encoded form URL-encoded body payload')
     }
   })
 })
 
 test('[REST mode] put /put', t => {
-  t.plan(5)
+  t.plan(16)
+  let path = '/put'
   tiny.put({
-    url: url + '/put',
+    url: url + path,
     data,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'put /put')
-      let { body, message, isBase64Encoded, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from put /put', 'Got correct handler response')
-      t.equal(b64dec(body), JSON.stringify(data), 'Got base64-encoded form URL-encoded body payload')
-      t.ok(isBase64Encoded, 'Got isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from put /put',
+        resource: path,
+        path,
+        httpMethod: 'PUT',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: true,
+        isBase64Encoded: true,
+      })
     }
   })
 })
 
 test('[REST mode] patch /patch', t => {
-  t.plan(5)
+  t.plan(16)
+  let path = '/patch'
   tiny.patch({
-    url: url + '/patch',
+    url: url + path,
     data,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'patched /patch')
-      let { body, message, isBase64Encoded, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from patch /patch', 'Got correct handler response')
-      t.equal(b64dec(body), JSON.stringify(data), 'Got base64-encoded form URL-encoded body payload')
-      t.ok(isBase64Encoded, 'Got isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from patch /patch',
+        resource: path,
+        path,
+        httpMethod: 'PATCH',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: true,
+        isBase64Encoded: true,
+      })
     }
   })
 })
 
 test('[REST mode] delete /delete', t => {
-  t.plan(5)
+  t.plan(16)
+  let path = '/delete'
   tiny.del({
-    url: url + '/delete',
+    url: url + path,
     data,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'deleted /delete')
-      let { body, message, isBase64Encoded, version } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from delete /delete', 'Got correct handler response')
-      t.equal(b64dec(body), JSON.stringify(data), 'Got base64-encoded form URL-encoded body payload')
-      t.ok(isBase64Encoded, 'Got isBase64Encoded flag')
+      checkResult(t, result.body, {
+        message: 'Hello from delete /delete',
+        resource: path,
+        path,
+        httpMethod: 'DELETE',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: null,
+        body: true,
+        isBase64Encoded: true,
+      })
     }
   })
 })
@@ -288,61 +423,76 @@ test('[REST mode] post / - route should fail when not explicitly defined, but on
 })
 
 test('[REST mode] get /foobar – route should fall through to greedy root', t => {
-  t.plan(8)
+  t.plan(16)
+  let path = '/foobar'
   tiny.get({
-    url: url + '/foobar',
+    url: url + path,
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /')
-      let { message, version, resource, path, pathParameters, requestContext } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from get / running the default runtime', 'Got correct handler response')
-      t.equal(resource, '/{proxy+}', 'Got correct resource param')
-      t.equal(path, '/foobar', 'Got correct path param')
-      t.equal(pathParameters.proxy, 'foobar', 'Got correct pathParameters.proxy')
-      t.equal(requestContext.path, '/foobar', 'Got correct requestContext.path param')
-      t.equal(requestContext.resourcePath, '/{proxy+}', 'Got correct requestContext.resourcePath param')
+      checkResult(t, result.body, {
+        message: 'Hello from get / running the default runtime',
+        resource: '/{proxy+}',
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: { proxy: 'foobar' },
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test('[REST mode] get /path/* – route should fall through to greedy root because catchalls are not supported in this mode', t => {
-  t.plan(8)
+  t.plan(16)
+  let path = '/path/hello/there'
   tiny.get({
-    url: url + '/path/hello/there'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /')
-      let { message, version, resource, path, pathParameters, requestContext } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from get / running the default runtime', 'Got correct handler response')
-      t.equal(resource, '/{proxy+}', 'Got correct resource param')
-      t.equal(path, '/path/hello/there', 'Got correct path param')
-      t.equal(pathParameters.proxy, 'path/hello/there', 'Got correct pathParameters.proxy')
-      t.equal(requestContext.path, '/path/hello/there', 'Got correct requestContext.path param')
-      t.equal(requestContext.resourcePath, '/{proxy+}', 'Got correct requestContext.resourcePath param')
+      checkResult(t, result.body, {
+        message: 'Hello from get / running the default runtime',
+        resource: '/{proxy+}',
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: { proxy: 'path/hello/there' },
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })
 
 test(`[REST mode] get /any – route should fall through to greedy root because 'any' is not supported in this mode`, t => {
-  t.plan(8)
+  t.plan(16)
+  let path = '/any'
   tiny.get({
-    url: url + '/any'
+    url: url + path
   }, function _got (err, result) {
     if (err) t.fail(err)
     else {
-      t.ok(result, 'got /')
-      let { message, version, resource, path, pathParameters, requestContext } = result.body
-      t.notOk(version, 'No Lambda payload version specified')
-      t.equal(message, 'Hello from get / running the default runtime', 'Got correct handler response')
-      t.equal(resource, '/{proxy+}', 'Got correct resource param')
-      t.equal(path, '/any', 'Got correct path param')
-      t.equal(pathParameters.proxy, 'any', 'Got correct pathParameters.proxy')
-      t.equal(requestContext.path, '/any', 'Got correct requestContext.path param')
-      t.equal(requestContext.resourcePath, '/{proxy+}', 'Got correct requestContext.resourcePath param')
+      checkResult(t, result.body, {
+        message: 'Hello from get / running the default runtime',
+        resource: '/{proxy+}',
+        path,
+        httpMethod: 'GET',
+        headers: '🤷🏽‍♀️',
+        multiValueHeaders: '🤷🏽‍♀️',
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        pathParameters: { proxy: 'any' },
+        body: null,
+        isBase64Encoded: false,
+      })
     }
   })
 })

--- a/test/integration/http/root-handling-test.js
+++ b/test/integration/http/root-handling-test.js
@@ -1,0 +1,249 @@
+let { join } = require('path')
+let tiny = require('tiny-json-http')
+let test = require('tape')
+let sandbox = require('../../../src')
+let { url, shutdownAsync } = require('./_utils')
+
+let cwd = process.cwd()
+let indexHTML = 'Hello from public/index.html!\n'
+
+test('Set up env', t => {
+  t.plan(1)
+  t.ok(sandbox, 'got sandbox')
+})
+
+async function setup (t, type, dir) {
+  process.env.ARC_API_TYPE = type
+  process.chdir(join(__dirname, '..', '..', 'mock', 'root-handling', dir))
+  let start = await sandbox.start({ quiet: true })
+  t.notOk(process.env.DEPRECATED, 'Arc v5 deprecated status NOT set')
+  t.equal(process.env.ARC_API_TYPE, type, `API type set to ${type}`)
+  t.equal(process.env.ARC_HTTP, 'aws_proxy', 'aws_proxy mode enabled')
+  t.equal(start, 'Sandbox successfully started', 'Sandbox started')
+}
+function teardown (t) {
+  delete process.env.ARC_API_TYPE
+  process.chdir(cwd)
+  t.notOk(process.env.ARC_API_TYPE, 'API type NOT set')
+  t.equal(process.cwd(), cwd, 'Switched back to original working dir')
+}
+
+/**
+ * Root param with nested exact match: /:param/there
+ */
+test('[HTTP mode] get /hi/there - root param at /:param/there', async t => {
+  t.plan(17)
+  await setup(t, 'http', 'param-exact')
+
+  let result
+  result = await tiny.get({ url })
+  t.equal(result.body, indexHTML, 'Got static index.html')
+
+  result = await tiny.get({ url: url + '/hi/there' })
+  t.ok(result, 'got /hi/there')
+  let { message, version, routeKey, rawPath, pathParameters, requestContext } = result.body
+  t.equal(version, '2.0', 'Got Lambda v2.0 payload')
+  t.equal(routeKey, 'GET /{param}/there', 'Got correct routeKey')
+  t.equal(message, 'Hello from get /:param/there running the default runtime', 'Got correct handler response')
+  t.equal(rawPath, '/hi/there', 'Got correct rawPath')
+  t.equal(pathParameters.param, 'hi', 'Got correct pathParameters.param')
+  t.equal(requestContext.http.method, 'GET', 'Got correct method')
+  t.equal(requestContext.http.path, '/hi/there', 'Got correct requestContext.http.path param')
+  t.equal(requestContext.routeKey, 'GET /{param}/there', 'Got correct requestContext.routeKey param')
+
+  await shutdownAsync(t)
+  teardown(t)
+})
+
+test('[HTTP v1.0 (REST) mode] get /hi/there - root param at /:param/there', async t => {
+  t.plan(16)
+  await setup(t, 'httpv1', 'param-exact')
+
+  let result
+  result = await tiny.get({ url })
+  t.equal(result.body, indexHTML, 'Got static index.html')
+
+  result = await tiny.get({ url: url + '/hi/there' })
+  t.ok(result, 'got /hi/there')
+  let { message, version, resource, path, pathParameters, requestContext } = result.body
+  t.equal(version, '1.0', 'Got Lambda v2.0 payload')
+  t.equal(message, 'Hello from get /:param/there running the default runtime', 'Got correct handler response')
+  t.equal(resource, '/{param}/there', 'Got correct resource param')
+  t.equal(path, '/hi/there', 'Got correct path param')
+  t.equal(pathParameters.param, 'hi', 'Got correct pathParameters.proxy')
+  t.equal(requestContext.path, '/hi/there', 'Got correct requestContext.path param')
+  t.equal(requestContext.resourcePath, '/{param}/there', 'Got correct requestContext.resourcePath param')
+
+  await shutdownAsync(t)
+  teardown(t)
+})
+
+// TODO fix this test
+// This shouldn't be possible, as /:param/whatever can't coexist with /{proxy+} ASAP in REST
+/*
+test('[REST mode] get /hi/there - root param at /:param/there', async t => {
+  t.plan(8)
+  await setup(t, 'rest', 'param-exact')
+
+  try {
+    await tiny.get({ url: url + '/hi/there' })
+    t.fail(`Should not have gotten result`)
+  }
+  catch (err) {
+    t.equal(err.statusCode, 403, 'Errors with 403')
+  }
+
+  await shutdownAsync(t)
+  teardown(t)
+})
+*/
+
+/**
+ * Root param only: /:param
+ */
+test('[HTTP mode] get / - root param at /:param', async t => {
+  t.plan(17)
+  await setup(t, 'http', 'root-param')
+
+  let result = await tiny.get({ url })
+  t.ok(result, 'got /')
+  let { message, version, routeKey, rawPath, pathParameters, requestContext } = result.body
+  t.equal(version, '2.0', 'Got Lambda v2.0 payload')
+  t.equal(routeKey, 'GET /{param}', 'Got correct routeKey')
+  t.equal(message, 'Hello from get /:param running the default runtime', 'Got correct handler response')
+  t.equal(requestContext.http.method, 'GET', 'Got correct method')
+  t.equal(rawPath, '/', 'Got correct rawPath')
+  t.equal(pathParameters.param, '', 'Got correct pathParameters.param')
+  t.equal(requestContext.http.method, 'GET', 'Got correct method')
+  t.equal(requestContext.http.path, '/', 'Got correct requestContext.http.path param')
+  t.equal(requestContext.routeKey, 'GET /{param}', 'Got correct requestContext.routeKey param')
+
+  await shutdownAsync(t)
+  teardown(t)
+})
+
+test('[HTTP v1.0 (REST) mode] get / - root param at /:param', async t => {
+  t.plan(15)
+  await setup(t, 'httpv1', 'root-param')
+
+  let result = await tiny.get({ url })
+  t.ok(result, 'got /')
+  let { message, version, resource, path, pathParameters, requestContext } = result.body
+  t.equal(version, '1.0', 'Got Lambda v2.0 payload')
+  t.equal(message, 'Hello from get /:param running the default runtime', 'Got correct handler response')
+  t.equal(resource, '/{param}', 'Got correct resource param')
+  t.equal(path, '/', 'Got correct path param')
+  t.equal(pathParameters.param, '', 'Got correct pathParameters.proxy')
+  t.equal(requestContext.path, '/', 'Got correct requestContext.path param')
+  t.equal(requestContext.resourcePath, '/{param}', 'Got correct requestContext.resourcePath param')
+
+  await shutdownAsync(t)
+  teardown(t)
+})
+
+// This shouldn't be possible, as /:param can't coexist with /{proxy+} ASAP in REST
+test('[REST mode] get / - root param at /:param', async t => {
+  t.plan(8)
+  await setup(t, 'rest', 'root-param')
+
+  try {
+    await tiny.get({ url })
+    t.fail(`Should not have gotten result`)
+  }
+  catch (err) {
+    t.equal(err.statusCode, 403, 'Errors with 403')
+  }
+
+  await shutdownAsync(t)
+  teardown(t)
+})
+
+/**
+ * Nothing dynamic in root, all ASAP all the time
+ */
+test('[HTTP mode] get / - ASAP', async t => {
+  t.plan(8)
+  await setup(t, 'http', 'asap')
+
+  let result = await tiny.get({ url })
+  t.equal(result.body, indexHTML, 'Got static index.html')
+
+  await shutdownAsync(t)
+  teardown(t)
+})
+
+test('[HTTP v1.0 (REST) mode] get / - ASAP', async t => {
+  t.plan(8)
+  await setup(t, 'httpv1', 'asap')
+
+  let result = await tiny.get({ url })
+  t.equal(result.body, indexHTML, 'Got static index.html')
+
+  await shutdownAsync(t)
+  teardown(t)
+})
+
+test('[REST mode] get / - ASAP', async t => {
+  t.plan(8)
+  await setup(t, 'rest', 'asap')
+
+  let result = await tiny.get({ url })
+  t.equal(result.body, indexHTML, 'Got static index.html')
+
+  await shutdownAsync(t)
+  teardown(t)
+})
+
+/**
+ * Root is greedy: retired for HTTP APIs in Arc 8, still available in REST mode
+ */
+test('[HTTP mode] get / - greedy index', async t => {
+  t.plan(8)
+  await setup(t, 'http', 'greedy-get-index')
+
+  try {
+    await tiny.get({ url: url + '/hi/there' })
+    t.fail(`Should not have gotten result`)
+  }
+  catch (err) {
+    t.equal(err.statusCode, 403, 'Errors with 403')
+  }
+
+  await shutdownAsync(t)
+  teardown(t)
+})
+
+test('[HTTP v1.0 (REST) mode] get / - greedy index', async t => {
+  t.plan(8)
+  await setup(t, 'httpv1', 'greedy-get-index')
+
+  try {
+    await tiny.get({ url: url + '/hi/there' })
+    t.fail(`Should not have gotten result`)
+  }
+  catch (err) {
+    t.equal(err.statusCode, 403, 'Errors with 403')
+  }
+
+  await shutdownAsync(t)
+  teardown(t)
+})
+
+test('[REST mode] get / - greedy index', async t => {
+  t.plan(15)
+  await setup(t, 'rest', 'greedy-get-index')
+
+  let result = await tiny.get({ url: url + '/hi/there' })
+  t.ok(result, 'got /')
+  let { message, version, resource, path, pathParameters, requestContext } = result.body
+  t.notOk(version, 'No Lambda payload version specified')
+  t.equal(message, 'Hello from get / running the default runtime', 'Got correct handler response')
+  t.equal(resource, '/{proxy+}', 'Got correct resource param')
+  t.equal(path, '/hi/there', 'Got correct path param')
+  t.equal(pathParameters.proxy, 'hi/there', 'Got null pathParameters.proxy')
+  t.equal(requestContext.path, '/hi/there', 'Got correct requestContext.path param')
+  t.equal(requestContext.resourcePath, '/{proxy+}', 'Got correct requestContext.resourcePath param')
+
+  await shutdownAsync(t)
+  teardown(t)
+})

--- a/test/integration/http/root-handling-test.js
+++ b/test/integration/http/root-handling-test.js
@@ -5,6 +5,7 @@ let sandbox = require('../../../src')
 let { url, shutdownAsync } = require('./_utils')
 
 let cwd = process.cwd()
+let mock = join(__dirname, '..', '..', 'mock')
 let indexHTML = 'Hello from public/index.html!'
 
 test('Set up env', t => {
@@ -14,7 +15,7 @@ test('Set up env', t => {
 
 async function setup (t, type, dir) {
   process.env.ARC_API_TYPE = type
-  process.chdir(join(__dirname, '..', '..', 'mock', 'root-handling', dir))
+  process.chdir(join(mock, 'root-handling', dir))
   let start = await sandbox.start({ quiet: true })
   t.notOk(process.env.DEPRECATED, 'Arc v5 deprecated status NOT set')
   t.equal(process.env.ARC_API_TYPE, type, `API type set to ${type}`)

--- a/test/integration/http/root-handling-test.js
+++ b/test/integration/http/root-handling-test.js
@@ -5,7 +5,7 @@ let sandbox = require('../../../src')
 let { url, shutdownAsync } = require('./_utils')
 
 let cwd = process.cwd()
-let indexHTML = 'Hello from public/index.html!\n'
+let indexHTML = 'Hello from public/index.html!'
 
 test('Set up env', t => {
   t.plan(1)
@@ -37,7 +37,7 @@ test('[HTTP mode] get /hi/there - root param at /:param/there', async t => {
 
   let result
   result = await tiny.get({ url })
-  t.equal(result.body, indexHTML, 'Got static index.html')
+  t.ok(result.body.startsWith(indexHTML), 'Got static index.html')
 
   result = await tiny.get({ url: url + '/hi/there' })
   t.ok(result, 'got /hi/there')
@@ -61,7 +61,7 @@ test('[HTTP v1.0 (REST) mode] get /hi/there - root param at /:param/there', asyn
 
   let result
   result = await tiny.get({ url })
-  t.equal(result.body, indexHTML, 'Got static index.html')
+  t.ok(result.body.startsWith(indexHTML), 'Got static index.html')
 
   result = await tiny.get({ url: url + '/hi/there' })
   t.ok(result, 'got /hi/there')
@@ -78,7 +78,7 @@ test('[HTTP v1.0 (REST) mode] get /hi/there - root param at /:param/there', asyn
   teardown(t)
 })
 
-// TODO fix this test
+// TODO fix this test, see: arc#982
 // This shouldn't be possible, as /:param/whatever can't coexist with /{proxy+} ASAP in REST
 /*
 test('[REST mode] get /hi/there - root param at /:param/there', async t => {
@@ -166,7 +166,7 @@ test('[HTTP mode] get / - ASAP', async t => {
   await setup(t, 'http', 'asap')
 
   let result = await tiny.get({ url })
-  t.equal(result.body, indexHTML, 'Got static index.html')
+  t.ok(result.body.startsWith(indexHTML), 'Got static index.html')
 
   await shutdownAsync(t)
   teardown(t)
@@ -177,7 +177,7 @@ test('[HTTP v1.0 (REST) mode] get / - ASAP', async t => {
   await setup(t, 'httpv1', 'asap')
 
   let result = await tiny.get({ url })
-  t.equal(result.body, indexHTML, 'Got static index.html')
+  t.ok(result.body.startsWith(indexHTML), 'Got static index.html')
 
   await shutdownAsync(t)
   teardown(t)
@@ -188,7 +188,7 @@ test('[REST mode] get / - ASAP', async t => {
   await setup(t, 'rest', 'asap')
 
   let result = await tiny.get({ url })
-  t.equal(result.body, indexHTML, 'Got static index.html')
+  t.ok(result.body.startsWith(indexHTML), 'Got static index.html')
 
   await shutdownAsync(t)
   teardown(t)

--- a/test/integration/no-arc-test.js
+++ b/test/integration/no-arc-test.js
@@ -24,7 +24,7 @@ test('Set up env', t => {
  */
 test('Start Sandbox without an Architect project manifest', t => {
   t.plan(1)
-  sandbox.start({}, function (err) {
+  sandbox.start({ quiet: true }, function (err) {
     if (err) t.fail('Sandbox failed (sync)')
     else t.pass('Sandbox started (sync)')
   })
@@ -60,7 +60,7 @@ test('Can list tables', t => {
   })
 })
 
-test('default tables present', t => {
+test('Default tables present', t => {
   t.plan(5)
   let defaultTables = [
     'app-default-production-arc-sessions',
@@ -79,7 +79,7 @@ test('default tables present', t => {
   })
 })
 
-test('shut down sandbox', t => {
+test('Shut down sandbox', t => {
   t.plan(2)
   sandbox.end(() => {
     tiny.get({ url }, err => {

--- a/test/integration/no-arc-test.js
+++ b/test/integration/no-arc-test.js
@@ -1,9 +1,11 @@
-let path = require('path')
+let { join } = require('path')
 let tiny = require('tiny-json-http')
 let test = require('tape')
-let sandbox = require('../../src')
+let sut = join(process.cwd(), 'src')
+let sandbox = require(sut)
 let getDBClient = require('../../src/tables/_get-db-client')
 let cwd = process.cwd()
+let mock = join(__dirname, '..', 'mock')
 let url = `http://localhost:${process.env.PORT || 3333}`
 
 // Verify sandbox shut down
@@ -14,7 +16,7 @@ let shutdown = (t, err) => {
 test('Set up env', t => {
   t.plan(1)
   t.ok(sandbox, 'Sandbox is present')
-  process.chdir(path.join(__dirname, '..', 'mock', 'no-arc'))
+  process.chdir(join(mock, 'no-arc'))
 })
 
 /**

--- a/test/integration/start-test.js
+++ b/test/integration/start-test.js
@@ -22,7 +22,7 @@ test('Set up env', t => {
 test('Async sandbox.start', async t => {
   t.plan(1)
   try {
-    await sandbox.start()
+    await sandbox.start({ quiet: true })
     t.pass('Sandbox started (async)')
   }
   catch (err) {
@@ -43,7 +43,7 @@ test('Async sandbox.end', async t => {
 
 test('Sync sandbox.start', t => {
   t.plan(1)
-  sandbox.start({}, function (err) {
+  sandbox.start({ quiet: true }, function (err) {
     if (err) t.fail('Sandbox failed (sync)')
     else t.pass('Sandbox started (sync)')
   })

--- a/test/integration/start-test.js
+++ b/test/integration/start-test.js
@@ -1,8 +1,10 @@
-let path = require('path')
+let { join } = require('path')
 let test = require('tape')
 let tiny = require('tiny-json-http')
-let sandbox = require('../../src')
+let sut = join(process.cwd(), 'src')
+let sandbox = require(sut)
 let cwd = process.cwd()
+let mock = join(__dirname, '..', 'mock')
 let url = `http://localhost:${process.env.PORT || 3333}`
 
 // Verify sandbox shut down
@@ -14,7 +16,7 @@ test('Set up env', t => {
   t.plan(2)
   t.ok(sandbox, 'Sandbox is present')
   t.ok(sandbox.start, 'sandbox.start module is present')
-  process.chdir(path.join(__dirname, '..', 'mock', 'normal'))
+  process.chdir(join(mock, 'normal'))
 })
 
 test('Async sandbox.start', async t => {

--- a/test/integration/tables-test.js
+++ b/test/integration/tables-test.js
@@ -6,11 +6,12 @@ let dynamo
 let TableName = 'mockapp-production-accounts'
 let TableName2 = 'mockapp-production-pets'
 let cwd = process.cwd()
+let mock = join(__dirname, '..', 'mock')
 
 test('Set up env', t => {
   t.plan(1)
   t.ok(tables, 'Tables module is present')
-  process.chdir(join(__dirname, '..', 'mock', 'normal'))
+  process.chdir(join(mock, 'normal'))
 })
 
 test('Async tables.start', async t => {

--- a/test/integration/tables-test.js
+++ b/test/integration/tables-test.js
@@ -17,7 +17,7 @@ test('Set up env', t => {
 test('Async tables.start', async t => {
   t.plan(1)
   try {
-    let result = await tables.start({})
+    let result = await tables.start({ quiet: true })
     t.equal(result, 'DynamoDB successfully started', 'Tables started (async)')
   }
   catch (err) {
@@ -58,7 +58,7 @@ test('Async tables.end', async t => {
 
 test('Sync tables.start', t => {
   t.plan(1)
-  tables.start({}, function (err, result) {
+  tables.start({ quiet: true }, function (err, result) {
     if (err) t.fail(err)
     else t.equal(result, 'DynamoDB successfully started', 'Tables started (sync)')
   })
@@ -178,7 +178,7 @@ test('Sync tables.end', t => {
 test('Sync tables.start (deprecated)', t => {
   t.plan(1)
   process.env.DEPRECATED = true
-  tables.start({}, function (err, result) {
+  tables.start({ quiet: true }, function (err, result) {
     if (err) t.fail(err)
     else t.equal(result, 'DynamoDB successfully started', 'Tables started (sync)')
   })

--- a/test/integration/z-cli-test.js
+++ b/test/integration/z-cli-test.js
@@ -1,6 +1,7 @@
 let cli = require('../../src/cli')
-let join = require('path').join
+let { join } = require('path')
 let test = require('tape')
+let mock = join(__dirname, '..', 'mock')
 
 /**
  * May take a few seconds to close all related threads
@@ -9,7 +10,7 @@ let test = require('tape')
 test('Set up env', t => {
   t.plan(1)
   // Assumes previous tests may have already set working dir to `mock`
-  process.chdir(join(__dirname, '..', 'mock', 'normal'))
+  process.chdir(join(mock, 'normal'))
   t.ok(cli, 'CLI is present')
 })
 

--- a/test/mock/normal/src/http/get-binary/index.js
+++ b/test/mock/normal/src/http/get-binary/index.js
@@ -4,11 +4,14 @@ const read = promisify(readFile)
 
 exports.handler = async (event) => {
   const favicon = await read('./favicon.ico')
-  const headers = { 'content-type': 'image/x-icon' }
-  if (event.version) headers.version = event.version
+  const body = event
+  body.message = 'Hello from get /binary'
   return {
     statusCode: 200,
-    headers,
+    headers: {
+      'content-type': 'image/x-icon',
+      body: JSON.stringify(body)
+    },
     isBase64Encoded: true,
     body: favicon.toString('base64'),
   }

--- a/test/mock/root-handling/asap/.arc
+++ b/test/mock/root-handling/asap/.arc
@@ -1,0 +1,4 @@
+@app
+mockapp
+
+@http

--- a/test/mock/root-handling/asap/public/index.html
+++ b/test/mock/root-handling/asap/public/index.html
@@ -1,0 +1,1 @@
+Hello from public/index.html!

--- a/test/mock/root-handling/greedy-get-index/.arc
+++ b/test/mock/root-handling/greedy-get-index/.arc
@@ -1,0 +1,5 @@
+@app
+mockapp
+
+@http
+get /

--- a/test/mock/root-handling/greedy-get-index/public/index.html
+++ b/test/mock/root-handling/greedy-get-index/public/index.html
@@ -1,0 +1,1 @@
+Hello from public/index.html!

--- a/test/mock/root-handling/greedy-get-index/src/http/get-index/.arc-config
+++ b/test/mock/root-handling/greedy-get-index/src/http/get-index/.arc-config
@@ -1,0 +1,5 @@
+@aws
+runtime nodejs10.x
+timeout 10
+# concurrency 1
+# memory 1152

--- a/test/mock/root-handling/greedy-get-index/src/http/get-index/index.js
+++ b/test/mock/root-handling/greedy-get-index/src/http/get-index/index.js
@@ -1,0 +1,9 @@
+exports.handler = async (event) => {
+  const body = event
+  body.message = 'Hello from get / running the default runtime'
+  return {
+    statusCode: 200,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body)
+  }
+}

--- a/test/mock/root-handling/param-exact/.arc
+++ b/test/mock/root-handling/param-exact/.arc
@@ -1,0 +1,5 @@
+@app
+mockapp
+
+@http
+get /:param/there

--- a/test/mock/root-handling/param-exact/public/index.html
+++ b/test/mock/root-handling/param-exact/public/index.html
@@ -1,0 +1,1 @@
+Hello from public/index.html!

--- a/test/mock/root-handling/param-exact/src/http/get-000param-there/.arc-config
+++ b/test/mock/root-handling/param-exact/src/http/get-000param-there/.arc-config
@@ -1,0 +1,5 @@
+@aws
+runtime nodejs10.x
+timeout 10
+# concurrency 1
+# memory 1152

--- a/test/mock/root-handling/param-exact/src/http/get-000param-there/index.js
+++ b/test/mock/root-handling/param-exact/src/http/get-000param-there/index.js
@@ -1,0 +1,9 @@
+exports.handler = async (event) => {
+  const body = event
+  body.message = 'Hello from get /:param/there running the default runtime'
+  return {
+    statusCode: 200,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body)
+  }
+}

--- a/test/mock/root-handling/root-param/.arc
+++ b/test/mock/root-handling/root-param/.arc
@@ -1,0 +1,5 @@
+@app
+mockapp
+
+@http
+get /:param

--- a/test/mock/root-handling/root-param/public/index.html
+++ b/test/mock/root-handling/root-param/public/index.html
@@ -1,0 +1,1 @@
+Hello from public/index.html!

--- a/test/mock/root-handling/root-param/src/http/get-000param/.arc-config
+++ b/test/mock/root-handling/root-param/src/http/get-000param/.arc-config
@@ -1,0 +1,5 @@
+@aws
+runtime nodejs10.x
+timeout 10
+# concurrency 1
+# memory 1152

--- a/test/mock/root-handling/root-param/src/http/get-000param/index.js
+++ b/test/mock/root-handling/root-param/src/http/get-000param/index.js
@@ -1,0 +1,9 @@
+exports.handler = async (event) => {
+  const body = event
+  body.message = 'Hello from get /:param running the default runtime'
+  return {
+    statusCode: 200,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body)
+  }
+}

--- a/test/unit/src-test.js
+++ b/test/unit/src-test.js
@@ -1,9 +1,9 @@
 let test = require('tape')
 let sandbox = require('../../src')
 
-test('sandbox', t => {
+test('Sandbox', t => {
   t.plan(2)
-  t.ok(sandbox, 'sandbox exists')
-  t.ok(typeof sandbox === 'object', 'is an object')
+  t.ok(sandbox, 'Sandbox exists!')
+  t.ok(typeof sandbox === 'object', '... and is an object')
   console.log(sandbox)
 })

--- a/test/unit/src/db/create-table/get-attribute-definitions-with-gsi-test.js
+++ b/test/unit/src/db/create-table/get-attribute-definitions-with-gsi-test.js
@@ -1,7 +1,7 @@
 let test = require('tape')
 let getDefns = require('../../../../../src/tables/create-table/_get-attribute-definitions-with-gsi.js')
 
-test('should not create duplicate table attribute definitions when indices reference a base table attribute definition', t => {
+test('Should not create duplicate table attribute definitions when indices reference a base table attribute definition', t => {
   t.plan(2)
   let baseAttrs = { PK: '*String', SK: '**String' }
   let tableName = 'staging-foo'

--- a/test/unit/src/http/http-req-fixtures.js
+++ b/test/unit/src/http/http-req-fixtures.js
@@ -125,6 +125,25 @@ let arc7 = {
     isBase64Encoded: false
   },
 
+  // get /{proxy+}
+  getProxyPlus: {
+    version: '2.0',
+    routeKey: 'GET /{proxy+}',
+    rawPath: '/nature/hiking',
+    rawQueryString: '',
+    cookies,
+    headers,
+    requestContext: {
+      http: {
+        method: 'GET',
+        path: '/nature/hiking',
+      },
+      routeKey: 'GET /{proxy+}',
+    },
+    pathParameters: { proxy: 'nature/hiking' },
+    isBase64Encoded: false
+  },
+
   // get /$default
   // Deprecated in Arc 8, but possibly added via Macro
   get$default: {
@@ -383,7 +402,7 @@ let arc6 = {
     multiValueHeaders,
     queryStringParameters: null,
     multiValueQueryStringParameters: null,
-    pathParameters: { proxy: '/nature/hiking' },
+    pathParameters: { proxy: 'nature/hiking' },
     body: null,
     isBase64Encoded: false,
     requestContext: {

--- a/test/unit/src/http/invoke-http/index-req-test.js
+++ b/test/unit/src/http/invoke-http/index-req-test.js
@@ -114,7 +114,6 @@ test('Architect v7 (HTTP API mode): get /?whats=up', t => {
     params: {}
   }
   handler(input, response)
-  // Compare handler-generated request to mock
   let req = lambdaStub.args[0][1]
   checkArcV7HttpResult(mock, req, t)
 })
@@ -133,7 +132,6 @@ test('Architect v7 (HTTP API mode): get /?whats=up&whats=there', t => {
     params: {}
   }
   handler(input, response)
-  // Compare handler-generated request to mock
   let req = lambdaStub.args[0][1]
   checkArcV7HttpResult(mock, req, t)
 })
@@ -152,7 +150,24 @@ test('Architect v7 (HTTP API mode): get /nature/hiking', t => {
     params: mock.pathParameters
   }
   handler(input, response)
-  // Compare handler-generated request to mock
+  let req = lambdaStub.args[0][1]
+  checkArcV7HttpResult(mock, req, t)
+})
+
+test('Architect v7 (HTTP API mode): get /{proxy+}', t => {
+  let mock = arc7.getProxyPlus
+  t.plan(httpParams.length)
+  let method = 'GET'
+  let route = '/*'
+  let apiType = 'http'
+  let handler = invoke({ method, route, apiType })
+  let input = {
+    url: url('/nature/hiking'),
+    body: {},
+    headers,
+    params: { '0': mock.pathParameters.proxy }
+  }
+  handler(input, response)
   let req = lambdaStub.args[0][1]
   checkArcV7HttpResult(mock, req, t)
 })
@@ -171,7 +186,6 @@ test('Architect v7 (HTTP API mode): get /path/* (/path/hi/there)', t => {
     params: { '0': mock.pathParameters.proxy }
   }
   handler(input, response)
-  // Compare handler-generated request to mock
   let req = lambdaStub.args[0][1]
   checkArcV7HttpResult(mock, req, t)
 })
@@ -191,7 +205,25 @@ test('Architect v7 (HTTP API mode): post /form (JSON)', t => {
     isBase64Encoded: false // Assumes flag is set in binary handler
   }
   handler(input, response)
-  // Compare handler-generated request to mock
+  let req = lambdaStub.args[0][1]
+  checkArcV7HttpResult(mock, req, t)
+})
+
+test('Architect v7 (HTTP + Lambda 1.0 payload): post /form (form URL encoded)', t => {
+  let mock = arc7.postFormURL
+  t.plan(httpParams.length)
+  let method = 'POST'
+  let route = '/form'
+  let apiType = 'http'
+  let handler = invoke({ method, route, apiType })
+  let input = {
+    url: url('/form'),
+    body: mock.body,
+    headers: mock.headers,
+    params: {},
+    isBase64Encoded: true
+  }
+  handler(input, response)
   let req = lambdaStub.args[0][1]
   checkArcV7HttpResult(mock, req, t)
 })
@@ -211,7 +243,6 @@ test('Architect v7 (HTTP API mode): post /form (multipart form data)', t => {
     isBase64Encoded: true // Assumes flag is set in binary handler
   }
   handler(input, response)
-  // Compare handler-generated request to mock
   let req = lambdaStub.args[0][1]
   checkArcV7HttpResult(mock, req, t)
 })
@@ -231,7 +262,6 @@ test('Architect v7 (HTTP API mode): post /form (octet stream)', t => {
     isBase64Encoded: true // Assumes flag is set in binary handler
   }
   handler(input, response)
-  // Compare handler-generated request to mock
   let req = lambdaStub.args[0][1]
   checkArcV7HttpResult(mock, req, t)
 })
@@ -251,7 +281,6 @@ test('Architect v7 (HTTP API mode): put /form (JSON)', t => {
     isBase64Encoded: false // Assumes flag is set in binary handler
   }
   handler(input, response)
-  // Compare handler-generated request to mock
   let req = lambdaStub.args[0][1]
   checkArcV7HttpResult(mock, req, t)
 })
@@ -271,7 +300,6 @@ test('Architect v7 (HTTP API mode): patch /form (JSON)', t => {
     isBase64Encoded: false // Assumes flag is set in binary handler
   }
   handler(input, response)
-  // Compare handler-generated request to mock
   let req = lambdaStub.args[0][1]
   checkArcV7HttpResult(mock, req, t)
 })
@@ -291,7 +319,6 @@ test('Architect v7 (HTTP API mode): delete /form (JSON)', t => {
     isBase64Encoded: false // Assumes flag is set in binary handler
   }
   handler(input, response)
-  // Compare handler-generated request to mock
   let req = lambdaStub.args[0][1]
   checkArcV7HttpResult(mock, req, t)
 })
@@ -429,15 +456,14 @@ test('Architect v7 (HTTP + Lambda 1.0 payload): get /{proxy+}', t => {
   let params = Object.keys(mock)
   t.plan(params.length + 2)
   let method = 'GET'
-  let route = '/'
+  let route = '/*'
   let apiType = 'httpv1'
   let handler = invoke({ method, route, apiType })
   let input = {
     url: url('/nature/hiking'),
-    resource: '/{proxy+}',
     body: {},
     headers,
-    params: mock.pathParameters
+    params: { '0': mock.pathParameters.proxy }
   }
   handler(input, response)
   let req = lambdaStub.args[0][1]
@@ -449,15 +475,14 @@ test('Architect v7 (HTTP + Lambda 1.0 payload): get /path/* (/path/hi/there)', t
   let params = Object.keys(mock)
   t.plan(params.length + 2)
   let method = 'GET'
-  let route = '/'
+  let route = '/path/*'
   let apiType = 'httpv1'
   let handler = invoke({ method, route, apiType })
   let input = {
     url: url('/path/hi/there'),
-    resource: '/path/{proxy+}',
     body: {},
     headers,
-    params: mock.pathParameters
+    params: { '0': mock.pathParameters.proxy }
   }
   handler(input, response)
   let req = lambdaStub.args[0][1]
@@ -502,7 +527,6 @@ test('Architect v7 (HTTP + Lambda 1.0 payload): post /form (form URL encoded)', 
   handler(input, response)
   let req = lambdaStub.args[0][1]
   checkArcV6RestResult(params, mock, req, t)
-  teardown()
 })
 
 test('Architect v7 (HTTP + Lambda 1.0 payload): post /form (multipart form data)', t => {
@@ -687,19 +711,20 @@ test('Architect v6 (REST API mode): get /nature/hiking', t => {
 })
 
 test('Architect v6 (REST API mode): get /{proxy+}', t => {
+  // Not normally how we'd do this test but get /{proxy+} in REST-land is only possible via greedy root, so resource, params, etc. are passed in via middleware
   let mock = arc6.getProxyPlus
   let params = Object.keys(mock)
   t.plan(params.length + 2)
   let method = 'GET'
-  let route = '/'
+  let route = '/' // Would normally be /*
   let apiType = 'rest'
   let handler = invoke({ method, route, apiType })
   let input = {
     url: url('/nature/hiking'),
-    resource: '/{proxy+}',
+    resource: '/{proxy+}', // The only time we should be using this
     body: {},
     headers,
-    params: mock.pathParameters
+    params: mock.pathParameters // Would normally be { '0': ... }
   }
   handler(input, response)
   let req = lambdaStub.args[0][1]
@@ -744,7 +769,6 @@ test('Architect v6 (REST API mode): post /form (form URL encoded)', t => {
   handler(input, response)
   let req = lambdaStub.args[0][1]
   checkArcV6RestResult(params, mock, req, t)
-  teardown()
 })
 
 test('Architect v6 (REST API mode): post /form (multipart form data)', t => {

--- a/test/unit/src/http/middleware/_static-path-test.js
+++ b/test/unit/src/http/middleware/_static-path-test.js
@@ -1,6 +1,6 @@
 let test = require('tape')
 let fs = require('fs')
-let path = require('path')
+let { join } = require('path')
 let sinon = require('sinon')
 let proxyquire = require('proxyquire')
 let sendStub = sinon.stub().returns({
@@ -9,7 +9,7 @@ let sendStub = sinon.stub().returns({
 })
 let origEnv = process.env.ARC_SANDBOX_PATH_TO_STATIC
 let origCwd = process.cwd()
-let mock = path.join(__dirname, '..', '..', '..', '..', 'mock', 'normal')
+let mock = join(__dirname, '..', '..', '..', '..', 'mock', 'normal')
 
 // Assigned in test
 let existsStub
@@ -27,7 +27,7 @@ test('Set up env', t => {
 test('_static test setup', t => {
   t.plan(1)
   process.chdir(mock)
-  process.env.ARC_SANDBOX_PATH_TO_STATIC = path.join(mock, 'public')
+  process.env.ARC_SANDBOX_PATH_TO_STATIC = join(mock, 'public')
   t.equals(process.cwd(), mock)
 })
 
@@ -51,7 +51,7 @@ test('_static should invoke send() with file location if url starts with _static
   existsStub.resetHistory()
   let statStub = sinon.stub(fs, 'statSync').returns({ isFile: sinon.fake.returns(true) })
   let req = { url: '/_static/my.css' }
-  let correct = path.join(mock, 'public', 'my.css')
+  let correct = join(mock, 'public', 'my.css')
   pub(req, null, sinon.fake())
   t.equals(existsStub.lastCall.args[0], correct, 'correct file checked for existence')
   t.equals(statStub.lastCall.args[0], correct, 'correct file stated')

--- a/test/unit/src/invoke-lambda/index-test.js
+++ b/test/unit/src/invoke-lambda/index-test.js
@@ -1,8 +1,9 @@
-let path = require('path')
+let { join } = require('path')
 let proxyquire = require('proxyquire')
 let sinon = require('sinon')
 let test = require('tape')
 let cwd = process.cwd()
+let mock = join(__dirname, '..', '..', '..', 'mock')
 
 // let spy = sinon.spy()
 let nodeFake = sinon.fake((options, request, timeout, callback) => callback(null, { options, request, timeout }))
@@ -18,7 +19,7 @@ let invoke = proxyquire('../../../../src/invoke-lambda', {
 
 test('Set up env', t => {
   t.plan(1)
-  process.chdir(path.join(__dirname, '..', '..', '..', 'mock', 'normal'))
+  process.chdir(join(mock, 'normal'))
   t.ok(invoke, 'Got invoke')
 })
 

--- a/test/unit/src/sandbox-test.js
+++ b/test/unit/src/sandbox-test.js
@@ -19,11 +19,11 @@ test('Set up env', t => {
   t.ok(sandbox.end, 'Found sandbox.end')
 })
 
-test('sandbox returns a Promise', async t => {
+test('Sandbox returns a Promise', async t => {
   t.plan(8)
   process.chdir(join(mock, 'no-functions'))
   try {
-    await sandbox.start()
+    await sandbox.start({ quiet: true })
     t.pass('sandbox.start returned Promise (without params)')
   }
   catch (err) {
@@ -197,7 +197,7 @@ test('Sandbox has correct env vars populated', async t => {
   }
 })
 
-test('sandbox (Architect v5) has correct env vars populated', async t => {
+test('Sandbox (Architect v5) has correct env vars populated', async t => {
   let roundsOfTesting = 3
   let tests = (roundsOfTesting * envVars.length) + (roundsOfTesting * 2)
   t.plan(tests)

--- a/test/unit/src/sandbox-test.js
+++ b/test/unit/src/sandbox-test.js
@@ -4,6 +4,7 @@ let sandbox = require('../../../src')
 let { join } = require('path')
 let series = require('run-series')
 let origCwd = process.cwd()
+let mock = join(__dirname, '..', '..', 'mock')
 let url = `http://localhost:${process.env.PORT || 3333}`
 
 // Verify sandbox shut down
@@ -20,7 +21,7 @@ test('Set up env', t => {
 
 test('sandbox returns a Promise', async t => {
   t.plan(8)
-  process.chdir(join(__dirname, '..', '..', 'mock', 'no-functions'))
+  process.chdir(join(mock, 'no-functions'))
   try {
     await sandbox.start()
     t.pass('sandbox.start returned Promise (without params)')
@@ -131,7 +132,7 @@ test('Sandbox has correct env vars populated', async t => {
   let roundsOfTesting = 3
   let tests = (roundsOfTesting * envVars.length) + (roundsOfTesting * 2)
   t.plan(tests)
-  process.chdir(join(__dirname, '..', '..', 'mock', 'normal'))
+  process.chdir(join(mock, 'normal'))
 
   // Architect 6+ (local)
   try {
@@ -200,7 +201,7 @@ test('sandbox (Architect v5) has correct env vars populated', async t => {
   let roundsOfTesting = 3
   let tests = (roundsOfTesting * envVars.length) + (roundsOfTesting * 2)
   t.plan(tests)
-  process.chdir(join(__dirname, '..', '..', 'mock', 'normal'))
+  process.chdir(join(mock, 'normal'))
 
   // Architect 5 (local)
   try {


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
