### PR TITLE
Adds TZ environment variable to Lambda invocation to match AWS environment

### DIFF
--- a/src/invoke-lambda/index.js
+++ b/src/invoke-lambda/index.js
@@ -49,6 +49,7 @@ module.exports = function invokeLambda (pathToLambda, event, callback) {
         PYTHONUNBUFFERED: true,
         PYTHONPATH: path.join(pathToLambda, 'vendor'),
         LAMBDA_TASK_ROOT: pathToLambda,
+        TZ: 'UTC',
       }
 
       let options = {

--- a/test/integration/http/misc-test.js
+++ b/test/integration/http/misc-test.js
@@ -107,7 +107,7 @@ test('[Catchall] get /get-c (matches with multiple child path parts)', t => {
 })
 
 test('[Env vars] get /env', t => {
-  t.plan(5)
+  t.plan(6)
   tiny.get({
     url: url + '/env'
   }, function _got (err, result) {
@@ -118,6 +118,7 @@ test('[Env vars] get /env', t => {
       t.ok(result.body.ARC_STATIC_BUCKET, 'Got ARC_STATIC_BUCKET env var')
       t.ok(result.body.NODE_ENV, 'Got NODE_ENV env var')
       t.ok(result.body.SESSION_TABLE_NAME, 'Got SESSION_TABLE_NAME env var')
+      t.equal(result.body.TZ, 'UTC', 'Got TZ env var')
     }
   })
 })


### PR DESCRIPTION
When using Sandbox, Node.js will default to the local time zone of the machine you're working on. When you execute code inside Lambda the time zone is always set to UTC.

Although you can mitigate this in your own code, it feels like this could trip developers up who are not aware that dates will behave differently between Sandbox and AWS.

This commit adds the `TZ` environment variable with the value `UTC` which changes local Node's behaviour to generate dates in the UTC timezone, the same as happens inside Lambda.

One slight wrinkle is that this is injected prior to choosing the runtime, so will also be exposed to Python/Ruby etc., but I noticed Python environment variables are already injected in the same place and it felt like the simplest place to implement this tweak. Happy to change based on responses.