### PR TITLE
CLI port fix if called in from arc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,13 @@
 
 ---
 
+## [3.3.1]
+
+### Fixed
+
+- Fixed `@architect/architect`'s ability to specify the port to run on from the
+    command line; fixes [#1023](https://github.com/architect/architect/issues/1023)
+
 ## [3.3.0] 2020-12-03
 
 ### Added

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -20,23 +20,6 @@ update({ pkg, shouldNotifyInNpmScript: true })
     dimBorder: true
   } })
 
-// Get the base port for HTTP / WebSockets; tables + events key off this
-// CLI args > env var
-function port () {
-  let port = Number(process.env.PORT) || 3333
-  let findPort = option => [ '-p', '--port', 'port' ].includes(option)
-  if (options && options.some(findPort)) {
-    let thePort = i => options[options.indexOf(i) + 1]
-    if (options.includes('-p'))
-      port = thePort('-p')
-    else if (options.includes('--port'))
-      port = thePort('--port')
-    else if (options.includes('port'))
-      port = thePort('port')
-  }
-  return port
-}
-
 // Hit it
 inventory({}, function (err, result) {
   if (err) {
@@ -47,7 +30,6 @@ inventory({}, function (err, result) {
     needsValidCreds: false,
     options,
     version: `Sandbox ${ver}`,
-    port: port(),
     inventory: result
   },
   function _done (err) {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -240,6 +240,10 @@ module.exports = function cli (params = {}, callback) {
       update.error(`Error:`, err)
     })
 
+    // Workaround for https://github.com/yuanchuan/node-watch/issues/105
+    // wait until watcher is ready before calling back, and when we do call
+    // back, provide a function to close the sandbox server, the watcher, and
+    // the stdin reader.
     watcher.on('ready', function () {
       if (callback) callback(null, function close () {
         watcher.on('close', function () {

--- a/test/integration/z-cli-test.js
+++ b/test/integration/z-cli-test.js
@@ -2,6 +2,7 @@ let cli = require('../../src/cli')
 let { join } = require('path')
 let test = require('tape')
 let mock = join(__dirname, '..', 'mock')
+let tiny = require('tiny-json-http')
 
 /**
  * May take a few seconds to close all related threads
@@ -14,14 +15,35 @@ test('Set up env', t => {
   t.ok(cli, 'CLI is present')
 })
 
-test('CLI sandbox', t => {
-  t.plan(1)
-  cli({}, function done (err) {
-    if (err) t.fail(err)
+const cliInv = {
+  inv: {
+    _project: { manifest: {} }
+  }
+}
+
+function doesIndexRouteWork (port, close, t) {
+  tiny.get({ url: `http://localhost:${port}/` }, function (e, res) {
+    if (e) t.fail(e)
     else {
-      t.pass('Sandbox CLI started')
+      t.equals(res.body.message, 'Hello from get / running the default runtime', 'correct response from http server')
+      close()
       t.end()
-      process.exit(0) // CLI holds process open, ofc
     }
+  })
+}
+
+test('CLI sandbox, no params', t => {
+  t.plan(1)
+  cli({ inventory: cliInv }, function done (err, close) {
+    if (err) t.fail(err)
+    else doesIndexRouteWork(process.env.PORT || 3333, close, t)
+  })
+})
+
+test('CLI sandbox, port specified', t => {
+  t.plan(1)
+  cli({ inventory: cliInv, options: [ '-p', '5432' ] }, function done (err, close) {
+    if (err) t.fail(err)
+    else doesIndexRouteWork(5432, close, t)
   })
 })


### PR DESCRIPTION
Fixes https://github.com/architect/architect/issues/1023

- Tweaks the main CLI module to call back with a function that will close everything down (sandbox, file watcher, stdin reader)
- Expanded CLI integration test to check for port functionality