### PR TITLE
Fix CORS middleware hang-up

### DIFF
--- a/src/http/middleware/_cors.js
+++ b/src/http/middleware/_cors.js
@@ -9,6 +9,7 @@ module.exports = function handleCors (req, res, next) {
       res.end()
       return
     }
+    else next()
   }
   else next()
 }


### PR DESCRIPTION
The sever doesn't do anything when `process.env.ARC_SANDBOX_ENABLE_CORS` is set and a http method other than `OPTIONS` is sent.

This will keep the request moving.

See: https://github.com/architect/architect/issues/1029