### PR TITLE
Fix issue where `any /*` could clobber the ability to send `@ws` mess…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ---
 
-## [3.3.1 - 3.3.2] 2020-12-06
+## [3.3.1 - 3.3.3] 2020-12-06
 
 ### Changed
 
@@ -16,7 +16,8 @@
 - Fixed alternative handler file checks when using Deno; fixes #1022
 - Fixed formatting in unknown `@http` userland error state
 - Fixed middleware handling `ARC_SANDBOX_ENABLE_CORS`; thanks @neilhoff!
-- Fixes serving bare `@static` (i.e. S3-only with no `@http`) apps; fixes #1031, thanks @dam!
+- Fixed serving bare `@static` (i.e. S3-only with no `@http`) apps; fixes #1031, thanks @dam!
+- Fixed issue where `any /*` could clobber the ability to send `@ws` messages locally; fixes #1039, thanks @mikemaccana!
 
 ---
 

--- a/src/http/index.js
+++ b/src/http/index.js
@@ -87,19 +87,19 @@ module.exports = function createHttpServer (inventory) {
         },
 
         function _finalSetup (callback) {
-          // Always register HTTP routes
-          if (inv.http) {
-            registerHTTP({ app, routes: inv.http })
-          }
-
           // Create an actual server; how quaint!
           httpServer = http.createServer(function _request (req, res) {
             app(req, res, finalhandler(req, res))
           })
 
           // Bind WebSocket app to HTTP server
+          // This must be done before @http so it isn't clobbered by greedy routes
           if (inv.ws) {
             websocketServer = registerWS({ app, httpServer, inventory })
+          }
+
+          if (inv.http) {
+            registerHTTP({ app, routes: inv.http })
           }
 
           callback()


### PR DESCRIPTION
…ages locally

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
