### PR TITLE
Feat/handle watcher limit error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,13 @@
 
 ---
 
+## [3.3.7] 2021-02-06
+
+### Added
+
+- Gracefully handle file watcher limit error
+
+---
 ## [3.3.6] 2021-01-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/sandbox",
-  "version": "3.3.6",
+  "version": "3.3.7-RC.0",
   "description": "Architect dev server: run full Architect projects locally & offline",
   "main": "src/index.js",
   "scripts": {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -25,7 +25,15 @@ module.exports = function cli (params = {}, callback) {
     // Setup
     let update = updater('Sandbox')
     let deprecated = process.env.DEPRECATED
-    let watcher = watch(process.cwd(), { recursive: true })
+
+    let watcher
+    try {
+      watcher = watch(process.cwd(), { recursive: true })
+    }
+    catch (e) {
+      update.warn('Automatic rehydration watcher failed: System limit for number of file watchers reached')
+    }
+
     let workingDirectory = pathToUnix(process.cwd())
 
     // Arc stuff
@@ -119,119 +127,121 @@ module.exports = function cli (params = {}, callback) {
     /**
      * Watch for pertinent filesystem changes
      */
-    watcher.on('change', function (event, fileName) {
+    if (watcher) {
+      watcher.on('change', function (event, fileName) {
 
-      if (!paused && fs.existsSync(pauseFile)) {
-        paused = true
-        update.status('Watcher temporarily paused')
-      }
-      if (paused && !fs.existsSync(pauseFile)) {
-        update.status('Watcher no longer paused')
-        paused = false
-        if (symlink) {
+        if (!paused && fs.existsSync(pauseFile)) {
+          paused = true
+          update.status('Watcher temporarily paused')
+        }
+        if (paused && !fs.existsSync(pauseFile)) {
+          update.status('Watcher no longer paused')
+          paused = false
+          if (symlink) {
+            rehydrate({
+              timer: arcEventTimer,
+              msg: 'Restoring shared file symlinks...',
+              force: true
+            })
+          }
+        }
+
+        // Event criteria
+        let fileUpdate = event === 'update'
+        let updateOrRemove = event === 'update' || event === 'remove'
+        fileName = pathToUnix(fileName)
+
+        /**
+         * Reload routes upon changes to Architect project manifest
+         */
+        if (fileUpdate && (fileName === manifest) && !paused) {
+          clearTimeout(arcEventTimer)
+          arcEventTimer = setTimeout(() => {
+            ts()
+            // Always attempt to close the http server, but only reload if necessary
+            sandbox.http.end()
+            update.status('Architect project manifest changed')
+
+            let start = Date.now()
+            let quiet = process.env.ARC_QUIET
+            process.env.ARC_QUIET = true
+            sandbox.http.start({ quiet: true }, function (err, result) {
+              if (!quiet) delete process.env.ARC_QUIET
+              if (err) update.err(err)
+              // HTTP passes back success message if it actually did need to (re)start
+              if (result === 'HTTP successfully started') {
+                let end = Date.now()
+                update.done(`HTTP routes reloaded in ${end - start}ms`)
+                if (deprecated) {
+                  rehydrate({
+                    timer: rehydrateArcTimer,
+                    only: 'arcFile',
+                    msg: 'Rehydrating functions with new project manifest'
+                  })
+                }
+              }
+            })
+          }, 50)
+        }
+
+        /**
+         * Rehydrate functions with shared files upon changes to src/shared
+         */
+        let isShared = fileName.includes(`${workingDirectory}/src/shared`)
+        if (updateOrRemove && isShared && !paused) {
           rehydrate({
-            timer: arcEventTimer,
-            msg: 'Restoring shared file symlinks...',
-            force: true
+            timer: rehydrateSharedTimer,
+            only: 'shared',
+            msg: 'Shared file changed, rehydrating functions...'
           })
         }
-      }
 
-      // Event criteria
-      let fileUpdate = event === 'update'
-      let updateOrRemove = event === 'update' || event === 'remove'
-      fileName = pathToUnix(fileName)
-
-      /**
-       * Reload routes upon changes to Architect project manifest
-       */
-      if (fileUpdate && (fileName === manifest) && !paused) {
-        clearTimeout(arcEventTimer)
-        arcEventTimer = setTimeout(() => {
-          ts()
-          // Always attempt to close the http server, but only reload if necessary
-          sandbox.http.end()
-          update.status('Architect project manifest changed')
-
-          let start = Date.now()
-          let quiet = process.env.ARC_QUIET
-          process.env.ARC_QUIET = true
-          sandbox.http.start({ quiet: true }, function (err, result) {
-            if (!quiet) delete process.env.ARC_QUIET
-            if (err) update.err(err)
-            // HTTP passes back success message if it actually did need to (re)start
-            if (result === 'HTTP successfully started') {
-              let end = Date.now()
-              update.done(`HTTP routes reloaded in ${end - start}ms`)
-              if (deprecated) {
-                rehydrate({
-                  timer: rehydrateArcTimer,
-                  only: 'arcFile',
-                  msg: 'Rehydrating functions with new project manifest'
-                })
-              }
-            }
+        /**
+         * Rehydrate functions with shared files upon changes to src/views
+         */
+        let isViews = fileName.includes(`${workingDirectory}/src/views`)
+        if (updateOrRemove && isViews && !paused) {
+          rehydrate({
+            timer: rehydrateViewsTimer,
+            only: 'views',
+            msg: 'Views file changed, rehydrating views...'
           })
-        }, 50)
-      }
+        }
 
-      /**
-       * Rehydrate functions with shared files upon changes to src/shared
-       */
-      let isShared = fileName.includes(`${workingDirectory}/src/shared`)
-      if (updateOrRemove && isShared && !paused) {
-        rehydrate({
-          timer: rehydrateSharedTimer,
-          only: 'shared',
-          msg: 'Shared file changed, rehydrating functions...'
-        })
-      }
-
-      /**
-       * Rehydrate functions with shared files upon changes to src/views
-       */
-      let isViews = fileName.includes(`${workingDirectory}/src/views`)
-      if (updateOrRemove && isViews && !paused) {
-        rehydrate({
-          timer: rehydrateViewsTimer,
-          only: 'views',
-          msg: 'Views file changed, rehydrating views...'
-        })
-      }
-
-      /**
-       * Regenerate public/static.json upon changes to public/
-       */
-      if (updateOrRemove && inv.static && !paused &&
+        /**
+         * Regenerate public/static.json upon changes to public/
+         */
+        if (updateOrRemove && inv.static && !paused &&
           fileName.includes(`${workingDirectory}/${staticFolder}`) &&
           !fileName.includes(`${workingDirectory}/${staticFolder}/static.json`)) {
-        clearTimeout(fingerprintTimer)
-        fingerprintTimer = setTimeout(() => {
-          let start = Date.now()
-          fingerprint({ inventory }, function next (err, result) {
-            if (err) update.error(err)
-            else {
-              if (result) {
-                let end = Date.now()
-                update.status(`Regenerated public/static.json in ${end - start}ms`)
-                rehydrate({
-                  timer: rehydrateStaticTimer,
-                  only: 'staticJson',
-                })
+          clearTimeout(fingerprintTimer)
+          fingerprintTimer = setTimeout(() => {
+            let start = Date.now()
+            fingerprint({ inventory }, function next (err, result) {
+              if (err) update.error(err)
+              else {
+                if (result) {
+                  let end = Date.now()
+                  update.status(`Regenerated public/static.json in ${end - start}ms`)
+                  rehydrate({
+                    timer: rehydrateStaticTimer,
+                    only: 'staticJson',
+                  })
+                }
               }
-            }
-          })
-        }, 50)
-      }
+            })
+          }, 50)
+        }
 
-      lastEvent = Date.now()
-    })
+        lastEvent = Date.now()
+      })
 
-    /**
-     * Watch for sandbox errors
-     */
-    watcher.on('error', function (err) {
-      update.error(`Error:`, err)
-    })
+      /**
+       * Watch for sandbox errors
+       */
+      watcher.on('error', function (err) {
+        update.error(`Error:`, err)
+      })
+    }
   })
 }


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

Small change to stop the sandbox crashing when this error occurs:
```
Error: ENOSPC: System limit for number of file watchers reached
```

Instead this warning will be printed:
```
⚠️ Warning: Automatic rehydration watcher failed: System limit for number of file watchers reached
```

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [x] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [x] Summarized your changes in `changelog.md`
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
