### PR TITLE
Fixes issue ignoring aws-sdk missing dependency

### DIFF
--- a/src/invoke-lambda/warn.js
+++ b/src/invoke-lambda/warn.js
@@ -19,10 +19,7 @@ module.exports = function warn (params) {
     })
 
     // Remove AWS-SDK, that's bundled in Lambda
-    let awsSdk = missing.findIndex(dep => dep === 'aws-sdk')
-    if (awsSdk >= 0) {
-      missing.splice(awsSdk, 1)
-    }
+    missing = missing.filter(dep => !dep.endsWith('::aws-sdk'))
     // Do we still have anything left?
     if (missing.length) {
       let update = updater('Sandbox')


### PR DESCRIPTION
The absolute string match failed to match the `dir::package` format.