### PR TITLE
if malformed JSON is passed to the event bus server, gracefully catch it

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,11 @@
 
 ### Added
 
-- Gracefully handle file watcher limit error
+- Gracefully handle file watcher limit error; thanks @mawdesley!
+
+### Fixed
+
+- Gracefully error if malformed JSON is passed to the `@events` bus server.
 
 ---
 ## [3.3.6] 2021-01-27

--- a/src/events/_listener.js
+++ b/src/events/_listener.js
@@ -1,4 +1,4 @@
-let { fork } = require('child_process')
+let proc = require('child_process')
 let { join } = require('path')
 let chalk = require('chalk')
 
@@ -22,7 +22,17 @@ module.exports = function eventBusListener (inventory, req, res) {
   })
 
   req.on('end', () => {
-    let message = JSON.parse(body)
+    let message
+
+    try {
+      message = JSON.parse(body)
+    }
+    catch (e) {
+      res.statusCode = 400
+      res.end('Sandbox @event bus exception parsing request body')
+      return
+    }
+
     message.inventory = inventory
 
     // @queues
@@ -50,7 +60,7 @@ module.exports = function eventBusListener (inventory, req, res) {
     }
     else {
       // Spawn a fork of the Node process
-      let subprocess = fork(join(__dirname, '_subprocess.js'))
+      let subprocess = proc.fork(join(__dirname, '_subprocess.js'))
       subprocess.send(message)
       subprocess.on('message', function _message (msg) {
         if (!quiet) {

--- a/test/unit/src/events/_listener-test.js
+++ b/test/unit/src/events/_listener-test.js
@@ -1,0 +1,43 @@
+let test = require('tape')
+let sinon = require('sinon')
+let child_process = require('child_process')
+let forkStub = {
+  send: sinon.spy(),
+  on: () => {}
+}
+sinon.stub(child_process, 'fork').returns(forkStub)
+let events = require('../../../../src/events/_listener')
+
+let inv = { get: { queues: () => 'queue', events: () => 'event' } }
+let baseReq = {
+  on: (evt, cb) => cb('{}')
+}
+
+test('Event listener should send a queue message to subprocess fork on queue url', t => {
+  t.plan(3)
+  let req = Object.assign({ url: '/queues' }, baseReq)
+  let res = { end: sinon.spy() }
+  events(inv, req, res)
+  t.ok(forkStub.send.calledWithMatch({ lambda: 'queue', arcType: 'queue' }), 'send called with appropriate message object')
+  t.equals(res.statusCode, 200, 'response status code set to 200')
+  t.ok(res.end.calledWith('ok'), 'response end called with ok body')
+})
+
+test('Event listener should send an events message to subprocess fork on events url', t => {
+  t.plan(3)
+  let req = Object.assign({ url: '/events' }, baseReq)
+  let res = { end: sinon.spy() }
+  events(inv, req, res)
+  t.ok(forkStub.send.calledWithMatch({ lambda: 'event', arcType: 'event' }), 'send called with appropriate message object')
+  t.equals(res.statusCode, 200, 'response status code set to 200')
+  t.ok(res.end.calledWith('ok'), 'response end called with ok body')
+})
+
+test('Event listener should respond with HTTP 400 if malformed JSON is sent to it', t => {
+  t.plan(2)
+  let req = { on: (evt, cb) => cb('this is not a JSON body') }
+  let res = { end: sinon.spy() }
+  events(inv, req, res)
+  t.equals(res.statusCode, 400, 'response status code set to 400')
+  t.ok(res.end.calledWith('Sandbox @event bus exception parsing request body'), 'response end called with ok body')
+})


### PR DESCRIPTION
... and report back a reasonable HTTP-compatible error message.

This fixes architect/architect#1084