### PR TITLE
feat: add the api gateway error response

### DIFF
--- a/src/http/register-websocket/connection.js
+++ b/src/http/register-websocket/connection.js
@@ -7,6 +7,12 @@ module.exports = function connection ({ cwd, inventory, update, domainName }, co
   // Save this for send to use
   pool.register(connectionId, ws)
 
+  const respondToError = (err, resp) => {
+    if (err || resp && resp.statusCode >= 400) {
+      ws.send(JSON.stringify({ 'message': 'Internal server error', connectionId, 'requestId': 'xxxxxx=' }), noop)
+    }
+  }
+
   ws.on('message', function message (data, isBinary) {
     let msg = isBinary ? data : data.toString()
     let lambda
@@ -27,7 +33,7 @@ module.exports = function connection ({ cwd, inventory, update, domainName }, co
         update,
         connectionId,
         domainName,
-      }, noop)
+      }, respondToError)
     }
     else {
       let lambda = get.ws('default')
@@ -40,7 +46,7 @@ module.exports = function connection ({ cwd, inventory, update, domainName }, co
         update,
         connectionId,
         domainName,
-      }, noop)
+      }, respondToError)
     }
   })
 

--- a/test/mock/normal/app.arc
+++ b/test/mock/normal/app.arc
@@ -50,6 +50,7 @@ any     /any-p/:param
 hello
 custom
   src src/ws/custom-path
+error
 
 @tables
 accounts

--- a/test/mock/normal/src/ws/error/index.js
+++ b/test/mock/normal/src/ws/error/index.js
@@ -1,0 +1,13 @@
+let arc = require('@architect/functions')
+let tiny = require('tiny-json-http')
+
+exports.handler = async function ws (event) {
+  await tiny.post({
+    url: 'http://localhost:3433/',
+    body: {
+      functionName: 'error',
+      event,
+    },
+  })
+  return { statusCode: 500 }
+}


### PR DESCRIPTION
This adds appropriate error responses to websocket messages if functions fail or return a non 200 status code.

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [x] Added and/or updated unit tests (if appropriate)
  - [x] Added and/or updated integration tests (if appropriate)
- [x] Updated relevant documentation:
  - [x] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [x] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!

Closes https://github.com/architect/architect/issues/1093