### PR TITLE
Deno suppress diagnostic output

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ---
 
+### Added
+
+- Added `-quiet` flag to `deno run` statement, so `console.log` terminal output is easier to read
+
 ## [3.4.1] 2021-03-23
 
 ### Fixed

--- a/src/invoke-lambda/run-in-deno.js
+++ b/src/invoke-lambda/run-in-deno.js
@@ -3,6 +3,7 @@ let spawn = require('./spawn')
 
 module.exports = function runInNode (options, request, timeout, callback) {
   spawn('deno', [
-    'run', '-A', '--unstable', '--reload', path.join(__dirname, 'runtimes', 'deno.js')
+    'run', '-A', '--unstable', '--reload', '--quiet', path.join(__dirname, 'runtimes', 'deno.js')
   ], options, request, timeout, callback)
 }
+


### PR DESCRIPTION
When using the Deno runtime, the terminal output from sandbox locally is noisy - due to Deno's diagnostic output. This makes it difficult to read `console.log` statements. 

e.g. 

```
Download https://deno.land/std@0.89.0/fs/_util.ts
Download https://deno.land/std@0.92.0/testing/asserts.ts
Download https://deno.land/x/aws_sdk@v3.13.0.0/client-sso/endpoints.ts
Download https://deno.land/std@0.89.0/node/_util/_util_types.ts
Download https://deno.land/std@0.89.0/node/_util/_util_callbackify.ts
Download https://deno.land/std@0.89.0/node/_util/_util_promisify.ts
Download https://deno.land/std@0.92.0/testing/_diff.ts
Check file:///Users/martinhicks/Projects/semantic-app/common/any-catchall/index.ts

{
  "version": "2.0",
  "routeKey": "ANY /{proxy+}",
  "rawPath": "/aaa",
  "rawQueryString": "",
  "cookies": [
    "_idx=eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..M3nzxpS1-N-sHaIL.QPltVPFBLqd9Mb6BPSS3Mo3Bv4nuEK6Kuut2LvZpv28V8Xf9mm7JVusKTk9_Ed0-J3bM6XNcdEZ2n77tM_iCHJ56VbWpmmg09FIrqbNzokThMZSY3tA3jG-xYG0_1MCKFaWpvhi8wsQ38hAlWH8a1nkv4Ppkmc4WSnAaB3Blp50iX5M8tLm_5wlxZJIqbcquRdtLBtuA4nXJ1awPbaE0urkmpSH7YSnzLH7_xTgAIhJTEVpJobyrswDBGOfYn-vIkUxzFIvc22kuBNn2DUhYT0Wp-w2RK7YGHknfhIQtyeBj8xVWRUYBJ8BXYbhP7RIBDINkuJa2_x3cEGEXZ250aodErFqLOB7J_QzBBtZGubXvHlBnnffxMrvs0avdkligVQCIn7h0E9bAUPadFRKDeGhWmUlG9Iw-WUEXXONvf89A0z3FpwseONYNqc3JFs3a_vr2vtxQmALecKUxGiyFO_7kdpbMehlvzJwBCqYCDwJV16tnAeeq9loKn35HyWUKhqU5sSgW0euj9gv8aayLn6Yshm_x1_N6QwvteXSkz23MtYjdRik_OBz4iPEU9v7yVS-_cpNoKlpRJI62GsN7COI0HP17OgQz7k3VXHhcwbJeYkexM5IBkSKfBvZnh23YzE_4kYqBOlS8hWnIagPGX8e3hg2u7543uaqsnWFkxVm5gi1lXmT8IqC4Ax4qpL1E1a2csKVAT4JNVu6FC1ZakyTCNtHFzbvN-ldAKnov3BjacU8K5D6jtVZzYnTFH5SBsR0VBP2oPeq-RYNOKrfMCTnTVw.IWEgKgxDPnCXhuapJRKA-A"
  ],
  "headers": {
    "host": "localhost:3333",
    "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
    "upgrade-insecure-requests": "1",
    "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15",
    "accept-language": "en-gb",
    "accept-encoding": "gzip, deflate"
  },
  "requestContext": {
    "http": {
      "method": "GET",
      "path": "/aaa"
    },
    "routeKey": "ANY /{proxy+}"
  },
  "pathParameters": {
    "proxy": "aaa"
  },
  "isBase64Encoded": false,
  "session": {},
  "httpMethod": "GET",
  "body": {},
  "queryStringParameters": {},
  "resource": "/{proxy+}",
  "path": "/aaa",
  "method": "GET",
  "params": {
    "proxy": "aaa"
  },
  "query": {}
}

Download https://raw.githubusercontent.com/hicksy/functions/architect-functions-deno/src/http/async/index.js
Download https://raw.githubusercontent.com/hicksy/functions/architect-functions-deno/src/http/_res-fmt.js
Download https://raw.githubusercontent.com/hicksy/functions/architect-functions-deno/src/http/helpers/params.js
Download https://raw.githubusercontent.com/hicksy/functions/architect-functions-deno/src/http/session/read.js
Download https://raw.githubusercontent.com/hicksy/functions/architect-functions-deno/src/http/session/write.js
Download https://raw.githubusercontent.com/hicksy/functions/architect-functions-deno/src/http/helpers/body-parser.js
Download https://deno.land/std@0.93.0/node/querystring.ts
```

I've added the `--quiet` flag to the `deno run` statement so this output is suppressed. 

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [x] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
