### PR TITLE
enable loading of a custom tsconfig using the --config runtime flag. 

### DIFF
--- a/src/invoke-lambda/run-in-deno.js
+++ b/src/invoke-lambda/run-in-deno.js
@@ -1,8 +1,22 @@
 let path = require('path')
 let spawn = require('./spawn')
+let fs = require('fs')
 
 module.exports = function runInNode (options, request, timeout, callback) {
+
+  let denoGlobalConfigPath = path.join(options.cwd, 'vendor', 'views', 'deno.tsconfig.json')
+  let denoFunctionConfigPath = path.join(options.cwd, 'deno.tsconfig.json')
+  let denoConfig = '';
+
+  if(fs.existsSync(denoGlobalConfigPath)) {
+    denoConfig = `--config ${denoGlobalConfigPath}`
+  }
+
+  if(fs.existsSync(denoFunctionConfigPath)) {
+    denoConfig = `--config ${denoFunctionConfigPath}`
+  }
+
   spawn('deno', [
-    'run', '-A', '--unstable', '--reload', path.join(__dirname, 'runtimes', 'deno.js')
+    'run', '-A', '--unstable',  '--reload', `${denoConfig}`, path.join(__dirname, 'runtimes', 'deno.js')
   ], options, request, timeout, callback)
 }

--- a/src/invoke-lambda/run-in-deno.js
+++ b/src/invoke-lambda/run-in-deno.js
@@ -17,6 +17,6 @@ module.exports = function runInNode (options, request, timeout, callback) {
   }
 
   spawn('deno', [
-    'run', '-A', '--unstable',  '--reload', `${denoConfig}`, path.join(__dirname, 'runtimes', 'deno.js')
+    'run', '-A', '--unstable', '--reload', `${denoConfig}`, path.join(__dirname, 'runtimes', 'deno.js')
   ], options, request, timeout, callback)
 }

--- a/src/invoke-lambda/run-in-deno.js
+++ b/src/invoke-lambda/run-in-deno.js
@@ -6,13 +6,13 @@ module.exports = function runInNode (options, request, timeout, callback) {
 
   let denoGlobalConfigPath = path.join(options.cwd, 'vendor', 'views', 'deno.tsconfig.json')
   let denoFunctionConfigPath = path.join(options.cwd, 'deno.tsconfig.json')
-  let denoConfig = '';
+  let denoConfig = ''
 
-  if(fs.existsSync(denoGlobalConfigPath)) {
+  if (fs.existsSync(denoGlobalConfigPath)) {
     denoConfig = `--config ${denoGlobalConfigPath}`
   }
 
-  if(fs.existsSync(denoFunctionConfigPath)) {
+  if (fs.existsSync(denoFunctionConfigPath)) {
     denoConfig = `--config ${denoFunctionConfigPath}`
   }
 


### PR DESCRIPTION
I've mocked out how supporting custom Deno tsconfig could work in sandbox (and hopefully this would work in your custom layer too?) - [https://github.com/architect/architect/issues/1149](https://github.com/architect/architect/issues/1149)

Code will first look for a 'global' `deno.tsconfig.json` file within the `vendor/views` dir (I'm assuming `.tsx` handlers would only be useful for http views?)

Also, you can override on a per-function basis if for some reason you had different requirements across http views, so we also check the `cwd` of the invoked function for `deno.tsconfig.json` 

(function version will take precedence over there global views version)


e.g. The following `deno.tsconifg.json` file allows me to use NanoJSX

```
{
  "compilerOptions": {
    "lib": ["dom", "dom.iterable", "esnext", "deno.ns", "deno.unstable"],
    "jsxFactory": "h",
    "strictPropertyInitialization": false
  }
}
```



## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
