### PR TITLE
use `match` and `equals` instead of `ok` where possible in tape tests

### DIFF
--- a/test/integration/__dep-warn-test.js
+++ b/test/integration/__dep-warn-test.js
@@ -58,10 +58,10 @@ test('[Dependency warnings (basic)] Lambda has its own deps', t => {
     if (err) t.fail(err)
     else {
       // t.comment(`stdout data: ${data}`)
-      t.ok(data.includes(`Please run: cd ${join(process.cwd(), 'src', 'http', 'get-deps_in_lambda')}`), 'Got a dep warning on the correct Lambda (with instructions to install into the Lambda)')
-      t.notOk(data.includes('lambda-dep'), 'Did not get dep warning for a Lambda dep')
-      t.ok(data.includes('root-dep'), 'Got a dep warning for a root dep')
-      t.ok(data.includes('@architect/inventory'), 'Got a dep warning for an out of band dep')
+      t.match(data, new RegExp(`Please run: cd ${join(process.cwd(), 'src', 'http', 'get-deps_in_lambda').replace(/\\/g, '\\\\')}`), 'Got a dep warning on the correct Lambda (with instructions to install into the Lambda)')
+      t.doesNotMatch(data, /lambda-dep/, 'Did not get dep warning for a Lambda dep')
+      t.match(data, /root-dep/, 'Got a dep warning for a root dep')
+      t.match(data, new RegExp('@architect/inventory'), 'Got a dep warning for an out of band dep')
       t.equal(instructions(data), 1, 'Got correct number of dep warnings')
       reset()
     }
@@ -78,10 +78,10 @@ test('[Dependency warnings (basic)] Deps are in root', t => {
     // t.comment(`stdout data: ${data}`)
     if (err) t.fail(err)
     else {
-      t.notOk(data.includes(join(process.cwd(), 'src', 'http', 'get-deps_in_root')), 'Got a dep warning for the root (with instructions to install into the root)')
-      t.ok(data.includes('Please run: npm i'), 'Got instructions to install into the root')
-      t.notOk(data.includes('root-dep'), 'Got a dep warning for a root dep')
-      t.ok(data.includes('@architect/inventory'), 'Got a dep warning for an out of band dep')
+      t.doesNotMatch(data, new RegExp(join(process.cwd(), 'src', 'http', 'get-deps_in_root').replace(/\\/g, '\\\\')), 'Got a dep warning for the root (with instructions to install into the root)')
+      t.match(data, /Please run: npm i/, 'Got instructions to install into the root')
+      t.doesNotMatch(data, /root-dep/, 'Got a dep warning for a root dep')
+      t.match(data, new RegExp('@architect/inventory'), 'Got a dep warning for an out of band dep')
       t.equal(instructions(data), 1, 'Got correct number of dep warnings')
       reset()
     }
@@ -97,11 +97,10 @@ test('[Dependency warnings (basic)] Deps are in shared', t => {
     teardown()
     if (err) t.fail(err)
     else {
-      console.log(data)
-      t.notOk(data.includes(join(process.cwd(), 'src', 'http', 'get-deps_in_shared')), 'Got a dep warning for the shared (with instructions to install into the shared)')
-      t.ok(data.includes('Please run: npm i'), 'Got instructions to install into the shared')
-      t.notOk(data.includes('root-dep'), 'Got a dep warning for a root dep')
-      t.ok(data.includes('@architect/inventory'), 'Got a dep warning for an out of band dep')
+      t.doesNotMatch(data, new RegExp(join(process.cwd(), 'src', 'http', 'get-deps_in_shared').replace(/\\/g, '\\\\')), 'Got a dep warning for the shared (with instructions to install into the shared)')
+      t.match(data, /Please run: npm i/, 'Got instructions to install into the shared')
+      t.doesNotMatch(data, /root-dep/, 'Got a dep warning for a root dep')
+      t.match(data, new RegExp('@architect/inventory'), 'Got a dep warning for an out of band dep')
       t.equal(instructions(data), 1, 'Got correct number of dep warnings')
       reset()
     }
@@ -161,8 +160,7 @@ test('[Dependency warnings (shared - no packages)] Shared deps', t => {
     teardown()
     if (err) t.fail(err)
     else {
-      console.log(data)
-      t.notOk(data.includes('root-dep'), 'Did not get a dep warning')
+      t.doesNotMatch(data, /root-dep/, 'Did not get a dep warning')
       reset()
     }
   })
@@ -177,8 +175,7 @@ test('[Dependency warnings (shared - no packages)] Views deps', t => {
     teardown()
     if (err) t.fail(err)
     else {
-      console.log(data)
-      t.notOk(data.includes('root-dep'), 'Did not get a dep warning')
+      t.doesNotMatch(data, /root-dep/, 'Did not get a dep warning')
       reset()
     }
   })
@@ -212,11 +209,10 @@ test('[Dependency warnings (shared - packages in shared)] Missing shared deps lo
     teardown()
     if (err) t.fail(err)
     else {
-      console.log(data)
-      t.ok(data.includes(`Please run: cd ${join(process.cwd(), 'src', 'shared')}`), 'Got a dep warning on the correct Lambda (with instructions to install deps into src/shared)')
-      t.notOk(data.includes('lambda-dep'), 'Did not get dep warning for a Lambda dep')
-      t.ok(data.includes('root-dep'), 'Got a dep warning for a root dep')
-      t.ok(data.includes('@architect/inventory'), 'Got a dep warning for an out of band dep')
+      t.match(data, new RegExp(`Please run: cd ${join(process.cwd(), 'src', 'shared').replace(/\\/g, '\\\\')}`), 'Got a dep warning on the correct Lambda (with instructions to install deps into src/shared)')
+      t.doesNotMatch(data, /lambda-dep/, 'Did not get dep warning for a Lambda dep')
+      t.match(data, /root-dep/, 'Got a dep warning for a root dep')
+      t.match(data, new RegExp('@architect/inventory'), 'Got a dep warning for an out of band dep')
       t.equal(instructions(data), 2, 'Got correct number of dep warnings')
       reset()
     }
@@ -232,11 +228,10 @@ test('[Dependency warnings (shared - packages in shared)] Missing views deps loa
     teardown()
     if (err) t.fail(err)
     else {
-      console.log(data)
-      t.ok(data.includes(`Please run: cd ${join(process.cwd(), 'src', 'views')}`), 'Got a dep warning on the correct Lambda (with instructions to install deps into src/views)')
-      t.notOk(data.includes('lambda-dep'), 'Did not get dep warning for a Lambda dep')
-      t.ok(data.includes('root-dep'), 'Got a dep warning for a root dep')
-      t.ok(data.includes('@architect/inventory'), 'Got a dep warning for an out of band dep')
+      t.match(data, new RegExp(`Please run: cd ${join(process.cwd(), 'src', 'views').replace(/\\/g, '\\\\')}`), 'Got a dep warning on the correct Lambda (with instructions to install deps into src/views)')
+      t.doesNotMatch(data, /lambda-dep/, 'Did not get dep warning for a Lambda dep')
+      t.match(data, /root-dep/, 'Got a dep warning for a root dep')
+      t.match(data, new RegExp('@architect/inventory'), 'Got a dep warning for an out of band dep')
       t.equal(instructions(data), 2, 'Got correct number of dep warnings')
       reset()
     }
@@ -271,11 +266,10 @@ test('[Dependency warnings (shared - packages in Lambdas)] Missing shared deps l
     teardown()
     if (err) t.fail(err)
     else {
-      console.log(data)
-      t.ok(data.includes(`Please run: cd ${join(process.cwd(), 'src', 'http', 'get-shared')}`), 'Got a dep warning on the correct Lambda (with instructions to install into the Lambda)')
-      t.notOk(data.includes('lambda-dep'), 'Did not get dep warning for a Lambda dep')
-      t.ok(data.includes('root-dep'), 'Got a dep warning for a root dep')
-      t.ok(data.includes('@architect/inventory'), 'Got a dep warning for an out of band dep')
+      t.match(data, new RegExp(`Please run: cd ${join(process.cwd(), 'src', 'http', 'get-shared').replace(/\\/g, '\\\\')}`), 'Got a dep warning on the correct Lambda (with instructions to install into the Lambda)')
+      t.doesNotMatch(data, /lambda-dep/, 'Did not get dep warning for a Lambda dep')
+      t.match(data, /root-dep/, 'Got a dep warning for a root dep')
+      t.match(data, new RegExp('@architect/inventory'), 'Got a dep warning for an out of band dep')
       t.equal(instructions(data), 1, 'Got correct number of dep warnings')
       reset()
     }
@@ -291,11 +285,10 @@ test('[Dependency warnings (shared - packages in Lambdas)] Missing views deps lo
     teardown()
     if (err) t.fail(err)
     else {
-      console.log(data)
-      t.ok(data.includes(`Please run: cd ${join(process.cwd(), 'src', 'http', 'get-views')}`), 'Got a dep warning on the correct Lambda (with instructions to install into the Lambda)')
-      t.notOk(data.includes('lambda-dep'), 'Did not get dep warning for a Lambda dep')
-      t.ok(data.includes('root-dep'), 'Got a dep warning for a root dep')
-      t.ok(data.includes('@architect/inventory'), 'Got a dep warning for an out of band dep')
+      t.match(data, new RegExp(`Please run: cd ${join(process.cwd(), 'src', 'http', 'get-views').replace(/\\/g, '\\\\')}`), 'Got a dep warning on the correct Lambda (with instructions to install into the Lambda)')
+      t.doesNotMatch(data, /lambda-dep/, 'Did not get dep warning for a Lambda dep')
+      t.match(data, /root-dep/, 'Got a dep warning for a root dep')
+      t.match(data, new RegExp('@architect/inventory'), 'Got a dep warning for an out of band dep')
       t.equal(instructions(data), 1, 'Got correct number of dep warnings')
       reset()
     }
@@ -330,12 +323,11 @@ test('[Dependency warnings (shared - packages in shared + Lambdas)] Missing shar
     teardown()
     if (err) t.fail(err)
     else {
-      console.log(data)
-      t.ok(data.includes(`Please run: cd ${join(process.cwd(), 'src', 'http', 'get-shared')}`), 'Got a dep warning on the correct Lambda (with instructions to install into the Lambda)')
-      t.ok(data.includes(`Please run: cd ${join(process.cwd(), 'src', 'shared')}`), 'Got a dep warning on the correct Lambda (with instructions to install deps into src/shared)')
-      t.notOk(data.includes('lambda-dep'), 'Did not get dep warning for a Lambda dep')
-      t.ok(data.includes('another-root-dep'), 'Got a dep warning for a root dep')
-      t.ok(data.includes('@architect/inventory'), 'Got a dep warning for an out of band dep')
+      t.match(data, new RegExp(`Please run: cd ${join(process.cwd(), 'src', 'http', 'get-shared').replace(/\\/g, '\\\\')}`), 'Got a dep warning on the correct Lambda (with instructions to install into the Lambda)')
+      t.match(data, new RegExp(`Please run: cd ${join(process.cwd(), 'src', 'shared').replace(/\\/g, '\\\\')}`), 'Got a dep warning on the correct Lambda (with instructions to install deps into src/shared)')
+      t.doesNotMatch(data, /lambda-dep/, 'Did not get dep warning for a Lambda dep')
+      t.match(data, /another-root-dep/, 'Got a dep warning for a root dep')
+      t.match(data, new RegExp('@architect/inventory'), 'Got a dep warning for an out of band dep')
       t.equal(instructions(data), 2, 'Got correct number of dep warnings')
       reset()
     }
@@ -351,12 +343,11 @@ test('[Dependency warnings (shared - packages in shared + Lambdas)] Missing view
     teardown()
     if (err) t.fail(err)
     else {
-      console.log(data)
-      t.ok(data.includes(`Please run: cd ${join(process.cwd(), 'src', 'http', 'get-views')}`), 'Got a dep warning on the correct Lambda (with instructions to install into the Lambda)')
-      t.ok(data.includes(`Please run: cd ${join(process.cwd(), 'src', 'views')}`), 'Got a dep warning on the correct Lambda (with instructions to install deps into src/views)')
-      t.notOk(data.includes('lambda-dep'), 'Did not get dep warning for a Lambda dep')
-      t.ok(data.includes('another-root-dep'), 'Got a dep warning for a root dep')
-      t.ok(data.includes('@architect/inventory'), 'Got a dep warning for an out of band dep')
+      t.match(data, new RegExp(`Please run: cd ${join(process.cwd(), 'src', 'http', 'get-views').replace(/\\/g, '\\\\')}`), 'Got a dep warning on the correct Lambda (with instructions to install into the Lambda)')
+      t.match(data, new RegExp(`Please run: cd ${join(process.cwd(), 'src', 'views').replace(/\\/g, '\\\\')}`), 'Got a dep warning on the correct Lambda (with instructions to install deps into src/views)')
+      t.doesNotMatch(data, /lambda-dep/, 'Did not get dep warning for a Lambda dep')
+      t.match(data, /another-root-dep/, 'Got a dep warning for a root dep')
+      t.match(data, new RegExp('@architect/inventory'), 'Got a dep warning for an out of band dep')
       t.equal(instructions(data), 2, 'Got correct number of dep warnings')
       reset()
     }

--- a/test/integration/events-test.js
+++ b/test/integration/events-test.js
@@ -106,7 +106,7 @@ test('arc.events.publish (failure)', t => {
     payload: {}
   },
   function done (err) {
-    if (err) t.ok(err.message.includes('404'), 'Event not found')
+    if (err) t.match(err.message, /404/, 'Event not found')
     else t.fail('Publish should have failed')
   })
 })
@@ -195,7 +195,7 @@ test('arc.queues.publish (failure)', t => {
     payload: {}
   },
   function done (err) {
-    if (err) t.ok(err.message.includes('404'), 'Event not found')
+    if (err) t.match(err.message, /404/, 'Event not found')
     else t.fail('Publish should have failed')
   })
 })

--- a/test/integration/http/deprecated-test.js
+++ b/test/integration/http/deprecated-test.js
@@ -117,7 +117,7 @@ test('[REST mode / deprecated] get /binary', t => {
         isBase64Encoded: undefined,
       })
       const img = Buffer.from(result.body).toString('base64')
-      t.ok(img.includes('AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAA'), 'is binary')
+      t.match(img, /AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAA/, 'is binary')
     }
   })
 })
@@ -323,7 +323,7 @@ test('[REST mode / deprecated] get /no-return (noop)', t => {
     if (err) {
       let message = 'Async error'
       t.equal(err.statusCode, 500, 'Errors with 500')
-      t.ok(err.body.includes(message), `Errors with message: '${message}'`)
+      t.match(err.body, new RegExp(message), `Errors with message: '${message}'`)
     }
     else t.fail(result)
   })
@@ -439,7 +439,7 @@ test('[REST mode / deprecated] post / - route should fail when not explicitly de
     if (err) {
       let message = '@http post /'
       t.equal(err.statusCode, 403, 'Errors with 403')
-      t.ok(err.body.includes(message), `Errors with message instructing to add '${message}' handler`)
+      t.match(err.body, new RegExp(message), `Errors with message instructing to add '${message}' handler`)
     }
     else t.fail(result)
   })
@@ -453,7 +453,7 @@ test('[REST mode / deprecated] get /foobar - route should fail when not explicit
     if (err) {
       let message = '@http get /foobar'
       t.equal(err.statusCode, 403, 'Errors with 403')
-      t.ok(err.body.includes(message), `Errors with message instructing to add '${message}' handler`)
+      t.match(err.body, new RegExp(message), `Errors with message instructing to add '${message}' handler`)
     }
     else t.fail(result)
   })
@@ -550,7 +550,7 @@ test('[REST mode / deprecated] get /missing should fail if missing its handler f
   }, function _got (err, result) {
     if (err) {
       t.equal(err.statusCode, 502, 'Got 502 for missing file')
-      t.ok(err.body.includes('Lambda handler not found'), 'Got correct error')
+      t.match(err.body, /Lambda handler not found/, 'Got correct error')
     }
     else t.fail(result)
   })

--- a/test/integration/http/http-test.js
+++ b/test/integration/http/http-test.js
@@ -162,7 +162,7 @@ test('[HTTP mode] get /binary', t => {
         isBase64Encoded: false,
       })
       const img = Buffer.from(result.body).toString('base64')
-      t.ok(img.includes('AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAA'), 'Body payload is binary')
+      t.match(img, /AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAA/, 'Body payload is binary')
     }
   })
 })
@@ -869,7 +869,7 @@ test('[HTTP mode] post / - route should fail when not explicitly defined', t => 
     if (err) {
       let message = '@http post /'
       t.equal(err.statusCode, 403, 'Errors with 403')
-      t.ok(err.body.includes(message), `Errors with message instructing to add '${message}' handler`)
+      t.match(err.body, new RegExp(message), `Errors with message instructing to add '${message}' handler`)
     }
     else t.fail(result)
   })
@@ -883,7 +883,7 @@ test('[HTTP mode] get /foobar - route should fail when not explicitly defined', 
     if (err) {
       let message = '@http get /foobar'
       t.equal(err.statusCode, 403, 'Errors with 403')
-      t.ok(err.body.includes(message), `Errors with message instructing to add '${message}' handler`)
+      t.match(err.body, new RegExp(message), `Errors with message instructing to add '${message}' handler`)
     }
     else t.fail(result)
   })
@@ -984,7 +984,7 @@ test('[HTTP mode] get /missing should fail if missing its handler file', t => {
   }, function _got (err, result) {
     if (err) {
       t.equal(err.statusCode, 502, 'Got 502 for missing file')
-      t.ok(err.body.includes('Lambda handler not found'), 'Got correct error')
+      t.match(err.body, /Lambda handler not found/, 'Got correct error')
     }
     else t.fail(result)
   })

--- a/test/integration/http/httpv1-test.js
+++ b/test/integration/http/httpv1-test.js
@@ -123,7 +123,7 @@ test('[HTTP v1.0 (REST) mode] get /binary', t => {
         isBase64Encoded: false,
       })
       const img = Buffer.from(result.body).toString('base64')
-      t.ok(img.includes('AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAA'), 'is binary')
+      t.match(img, /AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAA/, 'is binary')
     }
   })
 })
@@ -389,7 +389,7 @@ test('[HTTP v1.0 (REST) mode] get /no-return (noop)', t => {
     if (err) {
       let message = 'Async error'
       t.equal(err.statusCode, 500, 'Errors with 500')
-      t.ok(err.body.includes(message), `Errors with message: '${message}'`)
+      t.match(err.body, new RegExp(message), `Errors with message: '${message}'`)
     }
     else t.fail(result)
   })
@@ -817,7 +817,7 @@ test('[HTTP v1.0 (REST) mode] post / - route should fail when not explicitly def
     if (err) {
       let message = '@http post /'
       t.equal(err.statusCode, 403, 'Errors with 403')
-      t.ok(err.body.includes(message), `Errors with message instructing to add '${message}' handler`)
+      t.match(err.body, new RegExp(message), `Errors with message instructing to add '${message}' handler`)
     }
     else t.fail(result)
   })
@@ -831,7 +831,7 @@ test('[HTTP v1.0 (REST) mode] get /foobar - route should fail when not explicitl
     if (err) {
       let message = '@http get /foobar'
       t.equal(err.statusCode, 403, 'Errors with 403')
-      t.ok(err.body.includes(message), `Errors with message instructing to add '${message}' handler`)
+      t.match(err.body, new RegExp(message), `Errors with message instructing to add '${message}' handler`)
     }
     else t.fail(result)
   })
@@ -932,7 +932,7 @@ test('[HTTP v1.0 (REST) mode] get /missing should fail if missing its handler fi
   }, function _got (err, result) {
     if (err) {
       t.equal(err.statusCode, 502, 'Got 502 for missing file')
-      t.ok(err.body.includes('Lambda handler not found'), 'Got correct error')
+      t.match(err.body, /Lambda handler not found/, 'Got correct error')
     }
     else t.fail(result)
   })

--- a/test/integration/http/misc-test.js
+++ b/test/integration/http/misc-test.js
@@ -42,7 +42,7 @@ test('[Catchall] get /path - calls without trailing /* should fall through (and 
     if (err) {
       let message = '@http get /path'
       t.equal(err.statusCode, 403, 'Errors with 403')
-      t.ok(err.body.includes(message), `Errors with message instructing to add '${message}' handler`)
+      t.match(err.body, new RegExp(message), `Errors with message instructing to add '${message}' handler`)
     }
     else t.fail(result)
   })
@@ -121,8 +121,8 @@ test('[Timeout] get /times-out', t => {
       let message = 'Timeout Error'
       let time = '1 second'
       t.equal(err.statusCode, 500, 'Errors with 500')
-      t.ok(err.body.includes(message), `Errors with message: '${message}'`)
-      t.ok(err.body.includes(time), `Timed out set to ${time}`)
+      t.match(err.body, new RegExp(message), `Errors with message: '${message}'`)
+      t.match(err.body, new RegExp(time), `Timed out set to ${time}`)
     }
     else t.fail(result)
   })
@@ -136,7 +136,7 @@ test('[Oversized response] get /chonky', t => {
     if (err) {
       let message = 'Invalid payload size'
       t.equal(err.statusCode, 502, 'Errors with 502')
-      t.ok(err.body.includes(message), `Errors with message: '${message}'`)
+      t.match(err.body, new RegExp(message), `Errors with message: '${message}'`)
     }
     else t.fail(result)
   })
@@ -152,7 +152,7 @@ test('[Service discovery] get /_asd', t => {
       let services = result.body
       t.ok(services, 'Got back services object')
       t.ok(services.tables, 'Got back tables')
-      t.ok(Object.keys(services.tables).length, 4, 'Got back all tables')
+      t.equals(Object.keys(services.tables).length, 4, 'Got back all tables')
     }
   })
 })

--- a/test/integration/http/module-test.js
+++ b/test/integration/http/module-test.js
@@ -35,7 +35,7 @@ test('get /', t => {
       if (err) t.fail(err)
       else {
         t.ok(data, 'got /')
-        t.ok(data.body.message.includes('Hello from get / running the default runtime'), 'is hello world')
+        t.match(data.body.message, /Hello from get \/ running the default runtime/, 'is hello world')
       }
     })
 })
@@ -49,8 +49,8 @@ test('[Timeout] get /times-out', t => {
       let message = 'Timeout Error'
       let time = '1 second'
       t.equal(err.statusCode, 500, 'Errors with 500')
-      t.ok(err.body.includes(message), `Errors with message: '${message}'`)
-      t.ok(err.body.includes(time), `Timed out set to ${time}`)
+      t.match(err.body, new RegExp(message), `Errors with message: '${message}'`)
+      t.match(err.body, new RegExp(time), `Timed out set to ${time}`)
     }
     else t.fail(result)
   })
@@ -91,7 +91,7 @@ test('get /', t => {
       if (err) t.fail(err)
       else {
         t.ok(data, 'got /')
-        t.ok(data.body.message.includes('Hello from get / running the default runtime'), 'is hello world')
+        t.match(data.body.message, /Hello from get \/ running the default runtime/, 'is hello world')
       }
     })
 })

--- a/test/integration/http/rest-test.js
+++ b/test/integration/http/rest-test.js
@@ -123,7 +123,7 @@ test('[REST mode] get /binary', t => {
         isBase64Encoded: false,
       })
       const img = Buffer.from(result.body).toString('base64')
-      t.ok(img.includes('AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAA'), 'is binary')
+      t.match(img, /AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAA/, 'is binary')
     }
   })
 })
@@ -336,7 +336,7 @@ test('[REST mode] get /no-return (noop)', t => {
     if (err) {
       let message = 'Async error'
       t.equal(err.statusCode, 500, 'Errors with 500')
-      t.ok(err.body.includes(message), `Errors with message: '${message}'`)
+      t.match(err.body, new RegExp(message), `Errors with message: '${message}'`)
     }
     else t.fail(result)
   })
@@ -461,7 +461,7 @@ test('[REST mode] post / - route should fail when not explicitly defined, but on
     if (err) {
       let message = '@http post /'
       t.equal(err.statusCode, 403, 'Errors with 403')
-      t.ok(err.body.includes(message), `Errors with message instructing to add '${message}' handler`)
+      t.match(err.body, new RegExp(message), `Errors with message instructing to add '${message}' handler`)
     }
     else t.fail(result)
   })
@@ -637,7 +637,7 @@ test('[REST mode] get /missing should fail if missing its handler file', t => {
   }, function _got (err, result) {
     if (err) {
       t.equal(err.statusCode, 502, 'Got 502 for missing file')
-      t.ok(err.body.includes('Lambda handler not found'), 'Got correct error')
+      t.match(err.body, /Lambda handler not found/, 'Got correct error')
     }
     else t.fail(result)
   })

--- a/test/unit/src/http/invoke-http/http/_res-validate-test.js
+++ b/test/unit/src/http/invoke-http/http/_res-validate-test.js
@@ -58,7 +58,7 @@ test('Arc v6 response validity (HTTP)', t => {
   result = { statusCode: 'idk' }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('statusCode'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /statusCode/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   /**
@@ -72,7 +72,7 @@ test('Arc v6 response validity (HTTP)', t => {
   }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('buffer'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /buffer/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   res = newRes()
@@ -82,7 +82,7 @@ test('Arc v6 response validity (HTTP)', t => {
   }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('body'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /body/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   /**
@@ -92,14 +92,14 @@ test('Arc v6 response validity (HTTP)', t => {
   result = { headers: 'hi' }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('headers'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /headers/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   res = newRes()
   result = { headers: [ 'hi', 'there' ] }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('headers'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /headers/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   /**
@@ -109,7 +109,7 @@ test('Arc v6 response validity (HTTP)', t => {
   result = { cookies: 'hi' }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('cookies'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /cookies/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   /**
@@ -119,6 +119,6 @@ test('Arc v6 response validity (HTTP)', t => {
   result = { isBase64Encoded: 'hi' }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('isBase64Encoded'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /isBase64Encoded/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 })

--- a/test/unit/src/http/invoke-http/index-res-test.js
+++ b/test/unit/src/http/invoke-http/index-res-test.js
@@ -85,7 +85,7 @@ test('Unknown invocation error', t => {
 
   mock = arc7.noReturn
   run(mock, res => {
-    t.ok(res.body.includes(msg), 'Invocation error passes along error message')
+    t.match(res.body, new RegExp(msg), 'Invocation error passes along error message')
     t.equal(res.statusCode, 502, 'Responded with: 502')
   })
 
@@ -202,7 +202,7 @@ test('Architect v7 dependency-free responses (HTTP API mode)', t => {
 
   mock = arc7.invalid
   run(mock, res => {
-    t.ok(res.body.includes('Invalid response type'), 'Invalid statusCode causes error')
+    t.match(res.body, /Invalid response type/, 'Invalid statusCode causes error')
     t.equal(res.statusCode, 502, 'Responded with 502')
   })
 
@@ -234,7 +234,7 @@ test('Architect v7 dependency-free responses (HTTP API + Lambda v1.0)', t => {
 
   mock = arc6.buffer
   run(mock, res => {
-    t.ok(res.body.includes('Cannot respond with a raw buffer'), 'Raw buffer response causes error')
+    t.match(res.body, /Cannot respond with a raw buffer/, 'Raw buffer response causes error')
     t.equal(res.headers['content-type'], htmlUtf8, `Returned correct content-type: ${htmlUtf8}`)
     t.equal(res.statusCode, 502, 'Responded with 502')
   })
@@ -272,7 +272,7 @@ test('Architect v7 dependency-free responses (HTTP API + Lambda v1.0)', t => {
 
   mock = arc5.cookie
   run(mock, res => {
-    t.notOk(res.body.includes('Invalid response parameter'), 'Arc v5 style cookie parameter is ignored')
+    t.doesNotMatch(res.body, /Invalid response parameter/, 'Arc v5 style cookie parameter is ignored')
     t.equal(res.statusCode, 200, 'Responded with 200')
   })
 
@@ -284,7 +284,7 @@ test('Architect v7 dependency-free responses (HTTP API + Lambda v1.0)', t => {
 
   mock = arc6.invalidMultiValueHeaders
   run(mock, res => {
-    t.ok(res.body.includes('Invalid response type'), 'Invalid multiValueHeaders causes error')
+    t.match(res.body, /Invalid response type/, 'Invalid multiValueHeaders causes error')
     t.equal(res.statusCode, 502, 'Responded with 502')
   })
 
@@ -316,14 +316,14 @@ test('Architect v6 dependency-free responses (REST API mode)', t => {
 
   mock = arc6.buffer
   run(mock, res => {
-    t.ok(res.body.includes('Cannot respond with a raw buffer'), 'Raw buffer response causes error')
+    t.match(res.body, /Cannot respond with a raw buffer/, 'Raw buffer response causes error')
     t.equal(res.headers['content-type'], htmlUtf8, `Returned correct content-type: ${htmlUtf8}`)
     t.equal(res.statusCode, 502, 'Responded with 502')
   })
 
   mock = arc6.encodedWithBinaryTypeBad
   run(mock, res => {
-    t.ok(typeof res.body === 'string', 'Body is (likely) base64 encoded')
+    t.equals(typeof res.body, 'string', 'Body is (likely) base64 encoded')
     t.equal(b64dec(res.body), 'hi there\n', 'Body still base64 encoded')
     t.equal(res.headers['content-type'], 'application/pdf', `Returned correct content-type: application/pdf`)
     t.notOk(res.isBase64Encoded, 'isBase64Encoded param NOT set automatically')
@@ -354,7 +354,7 @@ test('Architect v6 dependency-free responses (REST API mode)', t => {
 
   mock = arc5.cookie
   run(mock, res => {
-    t.ok(res.body.includes('Invalid response parameter'), 'Arc v5 style cookie parameter causes error')
+    t.match(res.body, /Invalid response parameter/, 'Arc v5 style cookie parameter causes error')
     t.equal(res.statusCode, 502, 'Responded with 502')
   })
 
@@ -366,7 +366,7 @@ test('Architect v6 dependency-free responses (REST API mode)', t => {
 
   mock = arc6.invalidMultiValueHeaders
   run(mock, res => {
-    t.ok(res.body.includes('Invalid response type'), 'Invalid multiValueHeaders causes error')
+    t.match(res.body, /Invalid response type/, 'Invalid multiValueHeaders causes error')
     t.equal(res.statusCode, 502, 'Responded with 502')
   })
 
@@ -425,7 +425,7 @@ test('Architect v5 (REST API mode) & Architect Functions', t => {
 
   mock = arc5.defaultsToJson
   run(mock, res => {
-    t.ok(res.headers['Content-Type'].includes('application/json'), 'Unspecified content type defaults to JSON')
+    t.match(res.headers['Content-Type'], /application\/json/, 'Unspecified content type defaults to JSON')
     t.equal(res.statusCode, 200, 'Responded with 200')
   })
 

--- a/test/unit/src/http/invoke-http/rest/_res-validate-test.js
+++ b/test/unit/src/http/invoke-http/rest/_res-validate-test.js
@@ -55,7 +55,7 @@ test('Arc v6 response validity (HTTP + Lambda 1.0 payload)', t => {
   result = []
   check = responseValidator({ res, result }, true)
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('Handler must return an object'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /Handler must return an object/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   /**
@@ -65,7 +65,7 @@ test('Arc v6 response validity (HTTP + Lambda 1.0 payload)', t => {
   result = { statusCode: 'idk' }
   check = responseValidator({ res, result }, true)
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('statusCode'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /statusCode/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   /**
@@ -76,14 +76,14 @@ test('Arc v6 response validity (HTTP + Lambda 1.0 payload)', t => {
   result = { body: Buffer.from('hi') }
   check = responseValidator({ res, result }, true)
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('buffer'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /buffer/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   res = newRes()
   result = { body: data }
   check = responseValidator({ res, result }, true)
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('body'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /body/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   // This body is actually valid
@@ -101,14 +101,14 @@ test('Arc v6 response validity (HTTP + Lambda 1.0 payload)', t => {
   result = { headers: 'hi' }
   check = responseValidator({ res, result }, true)
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('headers'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /headers/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   res = newRes()
   result = { headers: [ 'hi', 'there' ] }
   check = responseValidator({ res, result }, true)
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('headers'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /headers/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   /**
@@ -118,21 +118,21 @@ test('Arc v6 response validity (HTTP + Lambda 1.0 payload)', t => {
   result = { multiValueHeaders: 'hi' }
   check = responseValidator({ res, result }, true)
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('multiValueHeaders'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /multiValueHeaders/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   res = newRes()
   result = { multiValueHeaders: [ 'hi', 'there' ] }
   check = responseValidator({ res, result }, true)
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('multiValueHeaders'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /multiValueHeaders/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   res = newRes()
   result = { multiValueHeaders: { 'hi': 'there' } }
   check = responseValidator({ res, result }, true)
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('multiValueHeaders'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /multiValueHeaders/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   /**
@@ -142,7 +142,7 @@ test('Arc v6 response validity (HTTP + Lambda 1.0 payload)', t => {
   result = { isBase64Encoded: 'hi' }
   check = responseValidator({ res, result }, true)
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('isBase64Encoded'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /isBase64Encoded/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   /**
@@ -194,7 +194,7 @@ test('Arc v6 response validity (REST API mode)', t => {
   result = []
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('Handler must return an object'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /Handler must return an object/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   /**
@@ -204,7 +204,7 @@ test('Arc v6 response validity (REST API mode)', t => {
   result = { statusCode: 'idk' }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('statusCode'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /statusCode/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   /**
@@ -215,14 +215,14 @@ test('Arc v6 response validity (REST API mode)', t => {
   result = { body: Buffer.from('hi') }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('buffer'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /buffer/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   res = newRes()
   result = { body: data }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('body'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /body/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   // This body is actually valid
@@ -239,14 +239,14 @@ test('Arc v6 response validity (REST API mode)', t => {
   result = { headers: 'hi' }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('headers'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /headers/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   res = newRes()
   result = { headers: [ 'hi', 'there' ] }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('headers'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /headers/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   /**
@@ -256,21 +256,21 @@ test('Arc v6 response validity (REST API mode)', t => {
   result = { multiValueHeaders: 'hi' }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('multiValueHeaders'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /multiValueHeaders/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   res = newRes()
   result = { multiValueHeaders: [ 'hi', 'there' ] }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('multiValueHeaders'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /multiValueHeaders/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   res = newRes()
   result = { multiValueHeaders: { 'hi': 'there' } }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('multiValueHeaders'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /multiValueHeaders/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   /**
@@ -280,7 +280,7 @@ test('Arc v6 response validity (REST API mode)', t => {
   result = { isBase64Encoded: 'hi' }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('isBase64Encoded'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /isBase64Encoded/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   /**
@@ -290,7 +290,7 @@ test('Arc v6 response validity (REST API mode)', t => {
   result = data
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('Invalid response parameter'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /Invalid response parameter/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   teardown()
@@ -335,7 +335,7 @@ test('Arc v5 response validity (REST API mode)', t => {
   result = []
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('Handler must return an object'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /Handler must return an object/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   /**
@@ -345,7 +345,7 @@ test('Arc v5 response validity (REST API mode)', t => {
   result = { statusCode: 'idk' }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('statusCode'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /statusCode/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   /**
@@ -356,7 +356,7 @@ test('Arc v5 response validity (REST API mode)', t => {
   result = { body: Buffer.from('hi') }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('buffer'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /buffer/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   // These bodies are actually valid
@@ -379,14 +379,14 @@ test('Arc v5 response validity (REST API mode)', t => {
   result = { headers: 'hi' }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('headers'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /headers/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   res = newRes()
   result = { headers: [ 'hi', 'there' ] }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('headers'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /headers/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   /**
@@ -396,21 +396,21 @@ test('Arc v5 response validity (REST API mode)', t => {
   result = { multiValueHeaders: 'hi' }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('multiValueHeaders'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /multiValueHeaders/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   res = newRes()
   result = { multiValueHeaders: [ 'hi', 'there' ] }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('multiValueHeaders'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /multiValueHeaders/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   res = newRes()
   result = { multiValueHeaders: { 'hi': 'there' } }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('multiValueHeaders'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /multiValueHeaders/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   /**
@@ -420,7 +420,7 @@ test('Arc v5 response validity (REST API mode)', t => {
   result = { isBase64Encoded: 'hi' }
   check = responseValidator({ res, result })
   t.equal(res.statusCode, 502, `Invalid response did not set error statusCode: ${res.statusCode}`)
-  t.ok(check.body.includes('isBase64Encoded'), `Got relevant error message: ${check.body}`)
+  t.match(check.body, /isBase64Encoded/, `Got relevant error message: ${check.body}`)
   t.equal(check.valid, false, `Invalid response returned valid: ${check.valid}`)
 
   /**


### PR DESCRIPTION
relates to architect/architect#1146