### PR TITLE
fix: promise returned from non async function acts like no response 

### DIFF
--- a/src/invoke-lambda/spawn.js
+++ b/src/invoke-lambda/spawn.js
@@ -168,13 +168,16 @@ module.exports = function spawnChild (params, callback) {
       else if (parsed) {
         // If it's an error pretty print it
         if (parsed.name && parsed.message && parsed.stack) {
-          parsed.body = `${head}
+          const body = `${head}
           <h1>${parsed.name}</h1>
           <p>${parsed.message}</p>
           <pre>${parsed.stack}</pre>
           `
-          parsed.code = 500
-          parsed.type = 'text/html'
+          return callback(null, {
+            statusCode: 500,
+            headers,
+            body,
+          })
         }
         // otherwise just return the command line
         callback(null, parsed)

--- a/test/integration/http/http-test.js
+++ b/test/integration/http/http-test.js
@@ -870,6 +870,36 @@ test('[HTTP mode] get /any-p/:param', t => {
   })
 })
 
+test('[HTTP mode] get /reject-promise should fail', t => {
+  t.plan(2)
+  tiny.get({
+    url: url + '/reject-promise'
+  }, function _got (err) {
+    if (err) {
+      t.equal(err.statusCode, 500, 'Got 500 for function error')
+      t.match(err.body, /Hello from get reject promise/, 'Got function error')
+    }
+    else {
+      t.fail('request should have failed')
+    }
+  })
+})
+
+test('[HTTP mode] get /throw-sync-error should fail', t => {
+  t.plan(2)
+  tiny.get({
+    url: url + '/throw-sync-error'
+  }, function _got (err) {
+    if (err) {
+      t.equal(err.statusCode, 500, 'Got 500 for function error')
+      t.match(err.body, /Hello from get throw sync error/, 'Got function error')
+    }
+    else {
+      t.fail('request should have failed')
+    }
+  })
+})
+
 /**
  * Arc v8+: routes are now literal, no more greedy root (`any /{proxy+}`) fallthrough
  */

--- a/test/integration/http/http-test.js
+++ b/test/integration/http/http-test.js
@@ -425,6 +425,21 @@ test('[HTTP mode] get /no-return (noop)', t => {
   })
 })
 
+test('[HTTP mode] get /promise-return (returned promise vs async function)', t => {
+  t.plan(2)
+  let rawPath = '/promise-return'
+  tiny.get({
+    url: url + rawPath
+  }, function _got (err, result) {
+    if (err) t.fail(err)
+    else {
+      t.ok(result, 'got /promise-return')
+      let { body } = result
+      t.equal(body.message, 'Hello from get promise-return', `Got 'Hello from get promise-return' string back`)
+    }
+  })
+})
+
 test('[HTTP mode] get /custom', t => {
   t.plan(15)
   let rawPath = '/custom'

--- a/test/mock/normal/app.arc
+++ b/test/mock/normal/app.arc
@@ -27,6 +27,8 @@ get     /get-p-c/:param/*
 get     /get-c/*
 get     /no-return
 get     /promise-return
+get     /reject-promise
+get     /throw-sync-error
 get     /times-out
 /custom
   method get

--- a/test/mock/normal/app.arc
+++ b/test/mock/normal/app.arc
@@ -26,6 +26,7 @@ get     /deno
 get     /get-p-c/:param/*
 get     /get-c/*
 get     /no-return
+get     /promise-return
 get     /times-out
 /custom
   method get

--- a/test/mock/normal/src/http/get-promise_return/index.js
+++ b/test/mock/normal/src/http/get-promise_return/index.js
@@ -1,0 +1,8 @@
+exports.handler = () => {
+  const body = { message: 'Hello from get promise-return' }
+  return Promise.resolve({
+    statusCode: 200,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body)
+  })
+}

--- a/test/mock/normal/src/http/get-reject_promise/index.js
+++ b/test/mock/normal/src/http/get-reject_promise/index.js
@@ -1,0 +1,3 @@
+exports.handler = async () => {
+  throw new Error('Hello from get reject promise')
+}

--- a/test/mock/normal/src/http/get-throw_sync_error/index.js
+++ b/test/mock/normal/src/http/get-throw_sync_error/index.js
@@ -1,0 +1,3 @@
+exports.handler = () => {
+  throw new Error('Hello from get throw sync error')
+}


### PR DESCRIPTION
# fixes!
This matches observed behavior in aws's node lambda handler for node 14 a follows the approach found in the node 12 handler's code for dealing with promise vs callback functions.

## Blocker
It would be ready to merge but! We have inconsistent error returns and I'm changing the behavior so I want to verify what we'd like to see.

I decided to compare our results to api gateway's lambda error results and came up with a [number of test cases in an arc project](https://github.com/reconbot/test-arc-project/tree/master/src/http). Api gateway does the same thing for everything (500 internal server error) the sandbox on the other hand does two different things depending on the function with the error.

### Sync errors show an html error page with 500 response
<img width="1591" alt="image" src="https://user-images.githubusercontent.com/25966/126077154-a3601c01-dc82-4ba5-963c-7ff343964931.png">

### Async errors show a json'd html error page with 200 response
<img width="1593" alt="image" src="https://user-images.githubusercontent.com/25966/126077163-b27078aa-4b03-4887-b8bc-9925e9a882f7.png">

I imagine that we want both cases to be html with the 500 response. This PR however moves both cases to be HTML. 

Investigating, we relied on stdout and no `__ARC__` response to print the html page. We caught async errors and sent them as json back to `spawn.js` however we seem to be getting hung up [here](https://github.com/architect/sandbox/blob/master/src/invoke-lambda/spawn.js#L170-L180) which incorrectly sets the statusCode and `type` (which I assume was some sort of proto headers thing).

If you can confirm the html errors are always desired this should be good to go! 

# Boilierplate
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [x] Added and/or updated unit tests (if appropriate)
  - [x] Added and/or updated integration tests (if appropriate)
- [x] Updated relevant documentation:
  - [x] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [x] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
