### PR TITLE
Add a context for lambda invocations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Architect Sandbox changelog
 
+## Unreleased
+
+- Added function context object with `functionName` and `functionVersion`. `functionName` will be similar to staging and production without the unique characters. `functionVersion` will always be `$latest`.
+
 ---
 
 ## [4.1.1] 2021-09-30

--- a/src/invoke-lambda/env.js
+++ b/src/invoke-lambda/env.js
@@ -1,4 +1,4 @@
-let { join } = require('path')
+let { join, sep: pathSeparator } = require('path')
 let { toLogicalID } = require('@architect/utils')
 
 // Constructs Lambda execution environment variables
@@ -8,6 +8,10 @@ module.exports = function getEnv (params) {
   let { inv } = inventory
   let { ARC_ENV, ARC_LOCAL, ARC_STATIC_SPA, NODE_ENV, PATH, SESSION_TABLE_NAME } = process.env
   let { AWS_ACCESS_KEY_ID, AWS_PROFILE, AWS_REGION, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN } = process.env
+
+  let srcParts = src.split(pathSeparator)
+  let functionName = srcParts.pop()
+  let functionType = srcParts.pop().toUpperCase()
 
   // Runtime environment variables
   let env = {
@@ -20,7 +24,10 @@ module.exports = function getEnv (params) {
     LAMBDA_TASK_ROOT: src,
     TZ: 'UTC',
     // Internal for handler bootstrap
-    __ARC_CONTEXT__: JSON.stringify({}), // TODO add more stuff to Lambda req context!
+    __ARC_CONTEXT__: JSON.stringify({
+      'functionName': `sandbox-${functionName}${functionType}`,
+      'functionVersion': '$LATEST',
+    }),
     __ARC_CONFIG__: JSON.stringify({
       projectSrc: cwd,
       handlerFile: 'index',

--- a/test/integration/http/http-test.js
+++ b/test/integration/http/http-test.js
@@ -45,6 +45,33 @@ function runTests (runType, t) {
     })
   })
 
+  t.test(`${mode} get /context`, t => {
+    t.plan(16)
+    tiny.get({
+      url: `${url}/context`
+    }, function _got (err, result) {
+      if (err) t.fail(err)
+      else {
+        t.equal(result.body.message, 'Hello from get /context running the default runtime')
+        checkResult(t, result.body.event, {
+          routeKey: 'GET /context',
+          rawPath: '/context',
+          pathParameters: undefined,
+          cookies: undefined,
+          queryStringParameters: undefined,
+          rawQueryString: '',
+          headers: '🤷🏽‍♀️',
+          isBase64Encoded: false,
+          body: undefined,
+        })
+        t.deepEqual(result.body.context, {
+          functionName: 'sandbox-get-contextHTTP',
+          functionVersion: '$LATEST',
+        })
+      }
+    })
+  })
+
   t.test(`${mode} get /?whats=up`, t => {
     t.plan(15)
     let rawQueryString = 'whats=up'

--- a/test/mock/normal/app.arc
+++ b/test/mock/normal/app.arc
@@ -15,6 +15,7 @@ queue-custom
 get     /           # runs default
 get     /multi-cookies-res
 get     /binary
+get     /context
 get     /nodejs12.x
 get     /nodejs10.x
 get     /nodejs8.10

--- a/test/mock/normal/src/http/get-context/index.js
+++ b/test/mock/normal/src/http/get-context/index.js
@@ -1,0 +1,9 @@
+exports.handler = async (event, context) => {
+  const body = { event, context }
+  body.message = 'Hello from get /context running the default runtime'
+  return {
+    statusCode: 200,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body)
+  }
+}


### PR DESCRIPTION
## Todo
- [x] functionName
- [x] functionVersion
- [ ] awsRequestId - should also match what's in the request context if the event has it (I know ws does not sure about the http events)

Works https://github.com/architect/architect/issues/1181

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [x] Added and/or updated unit tests (if appropriate)
  - [x] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [x] Summarized your changes in `changelog.md`
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
