### PR TITLE
fix: when using the api ports can be provided as a string for services

### DIFF
--- a/src/lib/ports.js
+++ b/src/lib/ports.js
@@ -8,7 +8,7 @@ function getPorts (port) {
   let { PORT, ARC_EVENTS_PORT, ARC_TABLES_PORT, ARC_INTERNAL } = process.env
 
   // CLI config (which are passed to this fn) > env var config
-  let httpPort = port || Number(PORT) || 3333
+  let httpPort = Number(port) || Number(PORT) || 3333
   let eventsPort = Number(ARC_EVENTS_PORT) || httpPort + 1
   let tablesPort = Number(ARC_TABLES_PORT) || 5000
   let _arcPort = Number(ARC_INTERNAL) || httpPort - 1


### PR DESCRIPTION
This works already for the sandbox as a whole but not for the services. This makes it work for the services.

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
