### PR TITLE
fix: shutting down the sandbox still fires websocket disconnect lambda

### DIFF
--- a/src/http/index.js
+++ b/src/http/index.js
@@ -16,6 +16,7 @@ let hydrate = require('@architect/hydrate')
 let registerHTTP = require('./register-http')
 let registerWS = require('./register-websocket')
 let prettyPrint = require('./_pretty-print')
+let pool = require('./register-websocket/pool')
 
 /**
  * Creates an HTTP + WebSocket server that emulates API Gateway
@@ -150,8 +151,10 @@ module.exports = function createHttpServer (inventory) {
           if (websocketServer) {
             websocketServer.close(err => {
               for (let ws of websocketServer.clients) {
+                ws.removeAllListeners('close')
                 ws.terminate()
               }
+              pool.reset()
               if (err) callback(err)
               else callback()
             })

--- a/src/http/register-websocket/pool.js
+++ b/src/http/register-websocket/pool.js
@@ -16,4 +16,8 @@ module.exports = {
     delete ledger[connectionId]
     delete times[connectionId]
   },
+  reset () {
+    ledger = {}
+    times = {}
+  }
 }


### PR DESCRIPTION
Connections were emitting the close event which would invoke the disconnect lambda when the sandbox was shutdown. This might not be awful but at this point we've usually also shutdown the service discovery, the DDB, the primary http server and SNS. So it's not great and has led to a lot of strange looking errors and crashes, especially when used in tests where you often don't care that every client has been disconnected before shutdown.

I need advice on testing this in sandbox but I have tested this with my websockets test suite on [graphql-lambda-subscriptions](https://github.com/reconbot/graphql-lambda-subscriptions) and internal applications.

The pool reset functionality is to prevent memory leaks on the global.

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
