### PR TITLE
Disable filesystem watching of node_modules and .git by default; fixes #1213

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,7 @@
 
 ---
 
-## [unreleased] 2021-xx-xx
-
+## [4.0.2] 2021-09-05
 
 ### Changed
 
@@ -15,6 +14,7 @@
 
 - Fixed CLI when parsing larger port numbers (e.g. `--port 33333`); fixes #1023, thanks @filmaj + LumaKernel!
 - Fixed inconsistent error reporting, thanks @reconbot!
+- Disable filesystem watching of node_modules and .git by default; fixes #1213
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/sandbox",
-  "version": "4.0.1",
+  "version": "4.0.2-RC.0",
   "description": "Architect dev server: run full Architect projects locally & offline",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "server-destroy": "~1.0.1",
     "tree-kill": "~1.2.2",
     "update-notifier": "~5.1.0",
-    "ws": "~8.2.0"
+    "ws": "~8.2.1"
   },
   "devDependencies": {
     "@architect/eslint-config": "~2.0.0",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -25,7 +25,14 @@ module.exports = function cli (params = {}, callback) {
 
     let watcher
     try {
-      watcher = watch(process.cwd(), { recursive: true })
+      watcher = watch(process.cwd(), {
+        recursive: true,
+        filter (file, skip) {
+          // Ignore changes to any node_modules dir + .git
+          if (/\/node_modules/.test(file) || /\.git/.test(file)) return skip
+          return true
+        }
+      })
     }
     catch (e) {
       update.warn('Automatic rehydration watcher failed: system file watcher limit may have been reached')


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
