### PR TITLE
Restore missing ARC_SANDBOX_PATH_TO_STATIC in Lambda env vars for manual ASAP use

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [4.1.1] 2021-09-30
+
+### Changed
+
+- Restored missing ARC_SANDBOX_PATH_TO_STATIC in Lambda env vars for manual ASAP use; fixes #1231, thanks @andybee!
+
+---
+
 ## [4.1.0] 2021-09-15
 
 ### Added

--- a/src/invoke-lambda/env.js
+++ b/src/invoke-lambda/env.js
@@ -62,6 +62,8 @@ module.exports = function getEnv (params) {
   // Env vars for users manually running ASAP in a Lambda
   if (inv.static) {
     env.ARC_STATIC_BUCKET = 'sandbox'
+    // TODO [REMOVE]: retire ARC_SANDBOX_PATH_TO_STATIC in next breaking change in favor of ARC_STATIC_BUCKET for better local/prod symmetry
+    env.ARC_SANDBOX_PATH_TO_STATIC = join(cwd, inv.static.folder)
     // Add userland ARC_STATIC_SPA if defined, otherwise we'll pick it up via Inv
     if (ARC_STATIC_SPA) {
       env.ARC_STATIC_SPA = ARC_STATIC_SPA


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
