### PR TITLE
Restore `ARC_INTERNAL` env var in Lambda invocations for Arc Functions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [next] 2021-10-05
+
+### Fixed
+
+- Restore `ARC_INTERNAL` env var in Lambda invocations for Arc Functions
+
+---
+
 ## [4.1.1] 2021-09-30
 
 ### Changed

--- a/src/invoke-lambda/env.js
+++ b/src/invoke-lambda/env.js
@@ -72,8 +72,10 @@ module.exports = function getEnv (params) {
 
   // Add ports and URLs if defined (and not an ASAP call)
   if (inv.ws)     env.ARC_WSS_URL     = `ws://localhost:${ports.httpPort}`
+  // TODO: only set ports env vars on local/testing env
   if (inv.events) env.ARC_EVENTS_PORT = ports.eventsPort
   if (inv.tables) env.ARC_TABLES_PORT = ports.tablesPort
+  env.ARC_INTERNAL = ports._arcPort
 
   // Runtime stuff
   if (config.runtime.startsWith('python')) {

--- a/test/unit/src/invoke-lambda/index-test.js
+++ b/test/unit/src/invoke-lambda/index-test.js
@@ -21,8 +21,9 @@ let invoke = proxyquire('../../../../src/invoke-lambda', {
 })
 let event = { something: 'happened' }
 let inventory = { inv: { app: 'hi' } }
+let ports = {}
 let userEnv = {}
-let params = { event, inventory, update, userEnv }
+let params = { event, inventory, update, userEnv, ports }
 let inv
 let get
 


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
