### PR TITLE
Alternative approach to console output from running functions

### DIFF
--- a/src/invoke-lambda/spawn.js
+++ b/src/invoke-lambda/spawn.js
@@ -218,12 +218,12 @@ module.exports = function spawnChild (params, callback) {
     if (midArcOutput) {
       return
     }
-    console.log(data.toString())
+    console.log(data.toString().trim())
   })
 
   child.stderr.on('data', data => {
     stderr += data
-    console.error(data.toString())
+    console.error(data.toString().trim())
     if (data.includes('__ARC_END__')) {
       maybeShutdown('stderr')
     }

--- a/src/invoke-lambda/spawn.js
+++ b/src/invoke-lambda/spawn.js
@@ -223,7 +223,7 @@ module.exports = function spawnChild (params, callback) {
 
   child.stderr.on('data', data => {
     stderr += data
-    console.error(data)
+    console.error(data.toString())
     if (data.includes('__ARC_END__')) {
       maybeShutdown('stderr')
     }

--- a/src/invoke-lambda/spawn.js
+++ b/src/invoke-lambda/spawn.js
@@ -218,12 +218,12 @@ module.exports = function spawnChild (params, callback) {
     if (midArcOutput) {
       return
     }
-    console.log(data.toString().trim())
+    process.stdout.write(data)
   })
 
   child.stderr.on('data', data => {
     stderr += data
-    console.error(data.toString().trim())
+    process.stderr.write(data)
     if (data.includes('__ARC_END__')) {
       maybeShutdown('stderr')
     }


### PR DESCRIPTION
This changes Sandbox behaviour so that when stdout/stderr output from a function, it now outputs stderr immediately and stdout after filtering __ARC__/__ARC_END__ messages, without waiting for all output to be buffered and returned on completion.

Whilst this isn't particularly improved for most function calls (particularly sub-second HTTP function calls), it can be useful when writing long running functions (such as event function), where development can be eased by returning states/debug/errors faster.

In my specific use case that triggered this, I had a bug in an event function involving an SFTP client that, when it occurred, meant the function was no longer doing what was expected and hung around until the timeout terminated it because of a hanging SFTP connection. Because the task is known to take a long time, the timeout was sat at the maximum 15 minutes so I was sat waiting 15 minutes each time for something that potentially error'ed within seconds. Whilst the code could be tweaked to avoid the hanging listener, it's a potential trip up we could also smooth over.