### PR TITLE
Add env start option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 ### Added
 
 - Sandbox now immediately streams Lambda logs to the console instead of printing everything all at once upon completion of execution; thanks @andybee!
+- Sandbox env parameter option allowing programmatic control (add, replace, delete) of user environment variables
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -75,7 +75,7 @@ Methods may be passed an options object containing the following parameters:
 - `symlink` - **Boolean** - Use symlinking to Architect shared code from within each Lambda's dependencies (e.g. `src/http/get-index/node_modules/@architect/shared` → `src/shared`)
   - Defaults to `true`
   - `false` copies shared code into each Lambda, which can result much slower startup and dependency rehydration speeds
-- `env` - **Object** - environment key/value entries overriding previous values if present (object entry values must be strings)
+- `env` - **Object** - environment key/value entries that add/replace user defined ones: string values will add/replace while primitive `undefined` values will delete
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ Methods may be passed an options object containing the following parameters:
 - `symlink` - **Boolean** - Use symlinking to Architect shared code from within each Lambda's dependencies (e.g. `src/http/get-index/node_modules/@architect/shared` → `src/shared`)
   - Defaults to `true`
   - `false` copies shared code into each Lambda, which can result much slower startup and dependency rehydration speeds
+- `env` - **Object** - environment key/value entries overriding previous values if present (object entry values must be strings)
 
 ---
 

--- a/src/lib/env/_user-env.js
+++ b/src/lib/env/_user-env.js
@@ -8,7 +8,7 @@ let { existsSync, readFileSync } = require('fs')
  * - e.g. if ARC_ENV=staging the Lambda env is populated by `@staging`, etc.
  */
 module.exports = function populateUserEnv (params, callback) {
-  let { cwd, update, inventory } = params
+  let { cwd, update, inventory, env } = params
   let { inv } = inventory
   let environment = process.env.ARC_ENV
   let setEnv = false // Ignore the second set of env vars if both .env + Arc prefs are found
@@ -82,6 +82,16 @@ module.exports = function populateUserEnv (params, callback) {
       let error = `.arc-env parse error: ${err.stack}`
       return callback(error)
     }
+  }
+  else if (env) {
+    Object.entries(env).forEach(entry => {
+      let [ key, value ] = entry
+      if (typeof value === 'string') userEnv[key] = value
+      else {
+        let error = `env option '${key}' non-string value parse error: ${new Error().stack}`
+        return callback(error)
+      }
+    })
   }
   else if (!setEnv) varsNotFound(environment)
 

--- a/src/lib/env/_user-env.js
+++ b/src/lib/env/_user-env.js
@@ -21,6 +21,13 @@ module.exports = function populateUserEnv (params, callback) {
   function print (env, file) {
     update.done(`Found ${env} environment variables: ${file}`)
   }
+  function uppercaseVarNames (userEnv) {
+    return Object.keys(userEnv).reduce(function (result, key) {
+      let value = userEnv[key]
+      result[key.toUpperCase()] = value
+      return result
+    }, {})
+  }
 
   let dotEnvPath = join(cwd, '.env')
   let legacyArcEnvPath = join(cwd, '.arc-env')
@@ -83,9 +90,13 @@ module.exports = function populateUserEnv (params, callback) {
       return callback(error)
     }
   }
-  else if (env) {
+  else if (!setEnv && !env) varsNotFound(environment)
+
+  userEnv = uppercaseVarNames(userEnv)
+  if (env) {
     Object.entries(env).forEach(entry => {
       let [ key, value ] = entry
+      key = key.toUpperCase()
       if (typeof value === 'string') userEnv[key] = value
       else if (typeof value === 'undefined') delete userEnv[key]
       else {
@@ -93,8 +104,8 @@ module.exports = function populateUserEnv (params, callback) {
         return callback(error)
       }
     })
+    print('testing', 'env option')
   }
-  else if (!setEnv) varsNotFound(environment)
 
   // Wrap it up
   if (inv._project?.preferences?.sandbox?.useAWS || process.env.ARC_LOCAL) {

--- a/src/lib/env/_user-env.js
+++ b/src/lib/env/_user-env.js
@@ -87,8 +87,9 @@ module.exports = function populateUserEnv (params, callback) {
     Object.entries(env).forEach(entry => {
       let [ key, value ] = entry
       if (typeof value === 'string') userEnv[key] = value
+      else if (typeof value === 'undefined') delete userEnv[key]
       else {
-        let error = `env option '${key}' non-string value parse error: ${new Error().stack}`
+        let error = `env option '${key}' parse error: ${new Error().stack}`
         return callback(error)
       }
     })

--- a/test/integration/http/misc-test.js
+++ b/test/integration/http/misc-test.js
@@ -171,19 +171,21 @@ function runTests (runType, t) {
     process.env.__TESTING_ENV_VAR__ = 'henlo'
     startup[runType](t, join('env', 'dot-env'), {
       env: {
-        DOTENV_USERLAND_ENV_VAR: 'Why hello there from overwritten .env!',
-        ENV_OPTION_USERLAND_ENV_VAR: 'Why hello there from env option!'
+        dotenv_userland_env_var: 'Why hello there from overwritten .env!',
+        ENV_OPTION_USERLAND_ENV_VAR: 'Why hello there from env option!',
+        env_option_case_test_userland_env_var: 'Userland env var names are uppercased!'
       }
     })
   })
 
   t.test(`[Env vars (env option)] get /env`, t => {
-    t.plan(8)
+    t.plan(9)
     tiny.get({ url }, function _got (err, result) {
       if (err) t.fail(err)
       else {
         t.equal(result.body.DOTENV_USERLAND_ENV_VAR, 'Why hello there from overwritten .env!', 'Received userland env var')
         t.equal(result.body.ENV_OPTION_USERLAND_ENV_VAR, 'Why hello there from env option!', 'Received userland env var')
+        t.equal(result.body.ENV_OPTION_CASE_TEST_USERLAND_ENV_VAR, 'Userland env var names are uppercased!', 'Received userland env var')
         t.ok(result.body.ARC_ENV, 'Got ARC_ENV env var')
         t.ok(result.body.ARC_STATIC_BUCKET, 'Got ARC_STATIC_BUCKET env var')
         t.ok(result.body.NODE_ENV, 'Got NODE_ENV env var')

--- a/test/integration/http/misc-test.js
+++ b/test/integration/http/misc-test.js
@@ -167,6 +167,38 @@ function runTests (runType, t) {
     shutdown[runType](t)
   })
 
+  t.test(`[Env vars (env option) / ${runType}] Start Sandbox`, t => {
+    process.env.__TESTING_ENV_VAR__ = 'henlo'
+    startup[runType](t, join('env', 'dot-env'), {
+      env: {
+        DOTENV_USERLAND_ENV_VAR: 'Why hello there from overwritten .env!',
+        ENV_OPTION_USERLAND_ENV_VAR: 'Why hello there from env option!'
+      }
+    })
+  })
+
+  t.test(`[Env vars (env option)] get /env`, t => {
+    t.plan(8)
+    tiny.get({ url }, function _got (err, result) {
+      if (err) t.fail(err)
+      else {
+        t.equal(result.body.DOTENV_USERLAND_ENV_VAR, 'Why hello there from overwritten .env!', 'Received userland env var')
+        t.equal(result.body.ENV_OPTION_USERLAND_ENV_VAR, 'Why hello there from env option!', 'Received userland env var')
+        t.ok(result.body.ARC_ENV, 'Got ARC_ENV env var')
+        t.ok(result.body.ARC_STATIC_BUCKET, 'Got ARC_STATIC_BUCKET env var')
+        t.ok(result.body.NODE_ENV, 'Got NODE_ENV env var')
+        t.ok(result.body.SESSION_TABLE_NAME, 'Got SESSION_TABLE_NAME env var')
+        t.equal(result.body.TZ, 'UTC', 'Got TZ env var')
+        t.notOk(result.body.__TESTING_ENV_VAR__, 'No system env var pollution')
+      }
+    })
+  })
+
+  t.test(`[Env vars (env option) / ${runType}] Shut down Sandbox`, t => {
+    delete process.env.__TESTING_ENV_VAR__
+    shutdown[runType](t)
+  })
+
   t.test(`[Env vars (preferences.arc) / ${runType}] Start Sandbox`, t => {
     process.env.__TESTING_ENV_VAR__ = 'henlo'
     startup[runType](t, join('env', 'preferences'))

--- a/test/integration/http/misc-test.js
+++ b/test/integration/http/misc-test.js
@@ -199,6 +199,43 @@ function runTests (runType, t) {
     shutdown[runType](t)
   })
 
+  t.test(`[Env vars (env option) remove / ${runType}] Start Sandbox`, t => {
+    process.env.__TESTING_ENV_VAR__ = 'henlo'
+    startup[runType](t, join('env', 'dot-env'), {
+      env: {
+        DOTENV_USERLAND_ENV_VAR: undefined,
+        ENV_OPTION_USERLAND_ENV_VAR: 'Why hello there from env option!',
+        ARC_ENV: undefined,
+        ARC_STATIC_BUCKET: undefined,
+        NODE_ENV: undefined,
+        SESSION_TABLE_NAME: undefined,
+        TZ: undefined
+      }
+    })
+  })
+
+  t.test(`[Env vars (env option) remove] get /env`, t => {
+    t.plan(8)
+    tiny.get({ url }, function _got (err, result) {
+      if (err) t.fail(err)
+      else {
+        t.notOk(result.body.DOTENV_USERLAND_ENV_VAR, 'Removed userland env var')
+        t.equal(result.body.ENV_OPTION_USERLAND_ENV_VAR, 'Why hello there from env option!', 'Received userland env var')
+        t.ok(result.body.ARC_ENV, 'Got ARC_ENV env var')
+        t.ok(result.body.ARC_STATIC_BUCKET, 'Got ARC_STATIC_BUCKET env var')
+        t.ok(result.body.NODE_ENV, 'Got NODE_ENV env var')
+        t.ok(result.body.SESSION_TABLE_NAME, 'Got SESSION_TABLE_NAME env var')
+        t.equal(result.body.TZ, 'UTC', 'Got TZ env var')
+        t.notOk(result.body.__TESTING_ENV_VAR__, 'No system env var pollution')
+      }
+    })
+  })
+
+  t.test(`[Env vars (env option) remove / ${runType}] Shut down Sandbox`, t => {
+    delete process.env.__TESTING_ENV_VAR__
+    shutdown[runType](t)
+  })
+
   t.test(`[Env vars (preferences.arc) / ${runType}] Start Sandbox`, t => {
     process.env.__TESTING_ENV_VAR__ = 'henlo'
     startup[runType](t, join('env', 'preferences'))


### PR DESCRIPTION
This PR solves a problem I faced after upgrading to the latest Sandbox code that deals with programmatically controlling what user environment is visible to the Sandbox server. Recent versions of the Sandbox appear to be using a child process for which user environment is controlled only via files. My use case for testing was doing this programmatically (the environment in older versions of Sandbox was shared).

**NOTE**: links to related type changes for TypeScript (branch is ready for PR to be created, just let me know if you want to proceed since the ReadMe for this "types" repo appeared to indicate a form of auto-merge was used):
* https://github.com/actsone8/DefinitelyTyped/blob/architect-sandbox-add-env-start-option/types/architect__sandbox/shared.d.ts
* https://github.com/actsone8/DefinitelyTyped/blob/architect-sandbox-add-env-start-option/types/architect__sandbox/architect__sandbox-tests.ts
* https://github.com/actsone8/DefinitelyTyped/blob/architect-sandbox-add-env-start-option/types/architect__sandbox/index.d.ts

PS. I've signed (a while ago) a CLA for arc.codes doc repo, but I can sign another one for this repo code change if required.