### PR TITLE
Enable `@architect/functions` to retrieve port configuration when run as a bare module

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@
 ### Added
 
 - Enable `@architect/functions` to retrieve port configuration when run as a bare module and not within a Lambda
+- Run startup commands via `@sandbox-start` preferences pragma
+  - This is a bit closer to `plugins.sandbox.start` than the existing `@sandbox-startup` preferences pragma
 
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,19 @@
 
 ---
 
+## [5.0.3] 2022-02-24
+
+### Added
+
+- Enable `@architect/functions` to retrieve port configuration when run as a bare module and not within a Lambda
+
+
+### Fixed
+
+- Fix missing `ARC_SANDBOX` env var `version` property in `sandbox.start` plugins + `@sandbox-startup` scripts
+
+---
+
 ## [5.0.2] 2022-02-22
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/sandbox",
-  "version": "5.0.2",
+  "version": "5.0.3-RC.0",
   "description": "Architect dev server: run full Architect projects locally & offline",
   "main": "src/index.js",
   "scripts": {

--- a/src/arc/_services.js
+++ b/src/arc/_services.js
@@ -1,8 +1,11 @@
 module.exports = function enumerateServices (params, callback) {
-  let { inventory } = params
+  let { inventory, ports } = params
   let { inv } = inventory
   let { app } = inv
   let services = {}
+
+  // Internal data for Arc Functions bare module fallbacks
+  services.ARC_SANDBOX = { ports: JSON.stringify(ports) }
 
   // Tables
   if (inv.tables) {

--- a/src/invoke-lambda/env/index.js
+++ b/src/invoke-lambda/env/index.js
@@ -1,8 +1,7 @@
 let { join } = require('path')
-let { readFileSync } = require('fs')
 let getContext = require('./context')
 let { userEnvVars } = require('../../lib')
-let { version } = JSON.parse(readFileSync(join(__dirname, '..', '..', '..', 'package.json')))
+let { version } = require('../../../package.json')
 
 // Assemble Lambda-specific execution environment variables
 module.exports = function getEnv (params) {

--- a/src/lib/user-env-vars.js
+++ b/src/lib/user-env-vars.js
@@ -1,4 +1,5 @@
 let { join } = require('path')
+let { version } = require('../../package.json')
 
 // Assemble Architect + userland env vars
 module.exports = function userEnvVars (params) {
@@ -10,7 +11,7 @@ module.exports = function userEnvVars (params) {
     ARC_APP_NAME: inv.app,
     ARC_ENV,
     ARC_ROLE: 'SandboxRole',
-    ARC_SANDBOX: JSON.stringify({ cwd, ports }),
+    ARC_SANDBOX: JSON.stringify({ cwd, ports, version }),
     ARC_SESSION_TABLE_NAME: ARC_SESSION_TABLE_NAME || SESSION_TABLE_NAME || 'jwe',
   }
 

--- a/src/sandbox/startup-scripts.js
+++ b/src/sandbox/startup-scripts.js
@@ -9,14 +9,16 @@ module.exports = function startupScripts (params, callback) {
   }
 
   let { preferences: prefs } = inventory.inv._project
+  // TODO [deprecate]: remove 'sandbox-startup' eventually
+  let startupCommands = prefs?.['sandbox-start'] || prefs?.['sandbox-startup']
 
-  if (prefs?.['sandbox-startup'] && runStartupCommands) {
+  if (startupCommands && runStartupCommands) {
     let now = Date.now()
     let ARC_INV = JSON.stringify(inventory.inv)
     let ARC_RAW = JSON.stringify(inventory.inv._project.arc)
     let envVars = userEnvVars(params)
     update.status('Running startup scripts')
-    let ops = prefs['sandbox-startup'].map(cmd => {
+    let ops = startupCommands.map(cmd => {
       return function (callback) {
         let env = { ...process.env, ARC_INV, ARC_RAW, ...envVars }
         exec(cmd, { cwd, env }, function (err, stdout, stderr) {

--- a/test/unit/src/arc/_ssm/services-test.js
+++ b/test/unit/src/arc/_ssm/services-test.js
@@ -4,7 +4,7 @@ let sut = join(process.cwd(), 'src', 'arc', '_services')
 let services = require(sut)
 
 test('Services should populate with plugin variables', t => {
-  t.plan(3)
+  t.plan(4)
   let pluginOne = () => ({ oneVar: 'yep' })
   let pluginTwo = () => ({ twoVar: 'yup' })
   pluginOne.plugin = 'pluginOne'
@@ -20,7 +20,8 @@ test('Services should populate with plugin variables', t => {
   services({ inventory }, (err, services) => {
     if (err) t.fail(err)
     else {
-      t.equal(Object.keys(services).length, 2, 'Got back two services')
+      t.equal(Object.keys(services).length, 3, 'Got back two services (and one internal)')
+      t.ok(services.ARC_SANDBOX, 'Got back internal SSM property')
       t.equal(services.pluginOne.oneVar, 'yep', 'First plugin variable created')
       t.equal(services.pluginTwo.twoVar, 'yup', 'Second plugin variable created')
     }


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
