### PR TITLE
Add SSM `ssm.getParameter()` support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,21 @@
 
 ---
 
+## [5.1.0] 2022-02-28
+
+### Added
+
+- Added SSM `ssm.getParameter()` support (in addition to `ssm.getParametersByPath()`)
+- Hardened Sandbox SSM emulation to have tighter query behavior, output valid errors, etc.
+
+
+### Fixed
+
+- Fixed Sandbox responding to all SSM requests indiscriminately
+  - Sandbox now only fulfills requests for the app that it's running (or for `@architect/functions` running as a bare module)
+
+---
+
 ## [5.0.3] 2022-02-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/sandbox",
-  "version": "5.0.3",
+  "version": "5.1.0-RC.0",
   "description": "Architect dev server: run full Architect projects locally & offline",
   "main": "src/index.js",
   "scripts": {

--- a/src/arc/_listener.js
+++ b/src/arc/_listener.js
@@ -1,7 +1,7 @@
 let _ssm = require('./_ssm')
 let _ws = require('./_ws')
 
-module.exports = function _arcListener (services, req, res) {
+module.exports = function _arcListener (services, params, req, res) {
   let body = ''
 
   req.on('data', chunk => {
@@ -10,7 +10,7 @@ module.exports = function _arcListener (services, req, res) {
 
   req.on('end', () => {
     if (req.url === '/_arc/ssm') {
-      _ssm({ body, services }, req, res)
+      _ssm({ body, services }, params, req, res)
       return
     }
     if (req.url.startsWith('/_arc/ws')) {

--- a/src/arc/_ssm/index.js
+++ b/src/arc/_ssm/index.js
@@ -1,5 +1,9 @@
-module.exports = function _ssm (params, req, res) {
-  let { body, services } = params
+let { toLogicalID } = require('@architect/utils')
+
+module.exports = function _ssm ({ body, services }, params, req, res) {
+  let { inventory, update } = params
+  let { app } = inventory.inv
+  let env = process.env.ARC_ENV
 
   if (req.method !== 'POST') {
     res.statusCode = 404
@@ -7,34 +11,98 @@ module.exports = function _ssm (params, req, res) {
     return
   }
 
-  let message, stack, serviceType
-  let Parameters = []
+  let error
   try {
-    message = JSON.parse(body)
-    let parts = message.Path.split('/').filter(Boolean)
-    stack = parts[0] // cloudformation stack name
-    serviceType = parts[1] // service type being requested
+    let message = JSON.parse(body)
+    let param, path, requestMethod, stack, serviceType
+
+    let exit = (__type, message = null) => {
+      error = { __type, message }
+      throw Error()
+    }
+
+    let sdkMethod = req.headers['x-amz-target']
+    if (sdkMethod === 'AmazonSSM.GetParametersByPath') {
+      requestMethod = 'getParametersByPath'
+      path = message.Path
+      if (!path) {
+        exit('MissingRequiredParameter', `Missing required key 'Path' in params`)
+      }
+    }
+    if (sdkMethod === 'AmazonSSM.GetParameter') {
+      requestMethod = 'getParameter'
+      path = message.Name
+      if (!path) {
+        exit('MissingRequiredParameter', `Missing required key 'Name' in params`)
+      }
+    }
+    if (!requestMethod) {
+      exit('InternalServerError', `Unrecognized request, Sandbox only supports 'getParameter', 'getParametersByPath'`)
+    }
+
+    let parts = path.split('/').filter(Boolean)
+    stack = parts[0]        // CloudFormation stack name
+    serviceType = parts[1]  // Service type being requested
+    param = parts[2]        // Param being requested
+
+    // Arc functions has a fallback to 'arc-app' when run as a bare module
+    let unknownApp = stack !== toLogicalID(`${app}-${env}`) &&
+                     stack !== toLogicalID(`arc-app-${env}`)
+
+    // Set up default response
+    res.statusCode = 200
+    res.setHeader('content-type', 'application/json')
+
+    let getParam = (param, Value, type) => ({
+      Name: `/${stack}/${type || serviceType}/${param}`,
+      Type: 'String',
+      Value,
+      Version: 1,
+      LastModifiedDate: new Date().toISOString(),
+      ARN: 'Architect Sandbox'
+    })
+
+    // ssm.getParametersByPath()
+    if (requestMethod === 'getParametersByPath') {
+      // SSM returns empty object if we can't find the app, service, or if a specific parameter is requested
+      if (unknownApp || (serviceType && !services[serviceType]) || param) {
+        res.end(JSON.stringify({ Parameters: [] }))
+        return
+      }
+      // Enumerate a single service
+      if (serviceType) {
+        let Parameters = Object.entries(services[serviceType]).map(([ p, v ]) => getParam(p, v))
+        res.end(JSON.stringify({ Parameters }))
+        return
+      }
+      // Enumerate all services
+      else {
+        let Parameters = []
+        Object.entries(services).forEach(([ type, service ]) => {
+          Object.entries(service).map(([ p, v ]) => Parameters.push(getParam(p, v, type)))
+        })
+        res.end(JSON.stringify({ Parameters }))
+        return
+      }
+    }
+    // ssm.getParameter()
+    else {
+      if (path.endsWith('/')) {
+        exit('ValidationException', `Parameter cannot end in '/'`)
+      }
+      if (unknownApp || !services[serviceType] || !services[serviceType][param]) {
+        exit(`ParameterNotFound`)
+      }
+      let Parameter = getParam(param, services[serviceType][param])
+      res.end(JSON.stringify({ Parameter }))
+      return
+    }
   }
-  catch (e) {
+  catch (err) {
+    update.verbose.warn(err)
     res.statusCode = 400
-    res.end('Sandbox service discovery exception parsing request body')
+    error = error || { __type: 'InternalServerError', message: 'Unknown Sandbox error: ' + err.stack }
+    res.end(JSON.stringify(error))
     return
   }
-
-  Object.entries(services).forEach(([ type, map ]) => {
-    Object.entries(map).forEach(([ key, Value ]) => {
-      if (!serviceType || type === serviceType) Parameters.push({
-        Name: `/${stack}/${type}/${key}`,
-        Type: 'String',
-        Value,
-        Version: 1,
-        LastModifiedDate: new Date(Date.now()).toISOString(),
-        ARN: 'Architect Sandbox'
-      })
-    })
-  })
-  res.statusCode = 200
-  res.setHeader('content-type', 'application/json')
-  res.end(JSON.stringify({ Parameters }))
-  return
 }

--- a/src/arc/index.js
+++ b/src/arc/index.js
@@ -18,7 +18,7 @@ function start (params, callback) {
   _services(params, function (err, services) {
     if (err) callback(err)
     else {
-      let listener = _listener.bind({}, services)
+      let listener = _listener.bind({}, services, params)
       _arcServices = http.createServer(listener)
       arc.livereload = _livereload(_arcServices, params)
       _arcServices.listen(ports._arc, err => {

--- a/test/integration/arc/ssm-test.js
+++ b/test/integration/arc/ssm-test.js
@@ -7,7 +7,7 @@ let sandbox = require(sut)
 let { credentials, run, startup, shutdown } = require('../../utils')
 let _arcPort = 2222
 
-let app = 'mockapp'
+let app = 'MockappTesting'
 let tables = [ 'accounts', 'pets', 'places', 'data' ]
 
 // AWS services to test
@@ -15,12 +15,13 @@ let endpoint = new aws.Endpoint(`http://localhost:${_arcPort}/_arc/ssm`)
 let httpOptions = { agent: new http.Agent() }
 let ssm = new aws.SSM({ endpoint, region: 'us-west-2', httpOptions, credentials })
 
-function check ({ result, type, items, t }) {
+function check ({ result, type, items, fallback, t }) {
   let internal = result.Parameters?.[0]?.Name?.includes('ARC_SANDBOX') ? 1 : 0
   t.equal(result.Parameters.length - internal, items.length, 'Got correct number of params')
   items.forEach(i => {
-    let key = `/${app}/${type}/${i}`
-    let value = `${app}-staging-${i}`
+    let stack = fallback ? 'ArcAppTesting' : app
+    let key = `/${stack}/${type}/${i}`
+    let value = `mockapp-staging-${i}`
     let found = result.Parameters.find(r => {
       return r.Name === key && r.Value === value
     })
@@ -45,28 +46,167 @@ function runTests (runType, t) {
     startup[runType](t, 'normal')
   })
 
+  /**
+   * ssm.getParametersByPath()
+   */
   t.test(`${mode} Get & check params (without specifying a type)`, t => {
-    t.plan(5)
+    t.plan(6)
     // Should get all tables params back
     ssm.getParametersByPath({ Path: `/${app}` }, function (err, result) {
       if (err) t.fail(err)
-      else check({ result, type: 'tables', items: tables, t })
+      else {
+        t.equal(result.Parameters.length, 5, 'Got back correct number of params')
+        check({ result, type: 'tables', items: tables, t })
+      }
+    })
+  })
+
+  t.test(`${mode} Get & check params (without specifying a type; Arc Functions bare module mode)`, t => {
+    t.plan(6)
+    // Should get all tables params back
+    ssm.getParametersByPath({ Path: `/ArcAppTesting` }, function (err, result) {
+      if (err) t.fail(err)
+      else {
+        t.equal(result.Parameters.length, 5, 'Got back correct number of params')
+        check({ result, type: 'tables', items: tables, fallback: true, t })
+      }
     })
   })
 
   t.test(`${mode} Get & check params (specifying a type)`, t => {
-    t.plan(5)
+    t.plan(6)
     ssm.getParametersByPath({ Path: `/${app}/tables` }, function (err, result) {
       if (err) t.fail(err)
-      else check({ result, type: 'tables', items: tables, t })
+      else {
+        t.equal(result.Parameters.length, 4, 'Got back correct number of params')
+        check({ result, type: 'tables', items: tables, t })
+      }
     })
   })
 
-  t.test(`${mode} Get & check params (specifying an invalid or unknown)`, t => {
+  t.test(`${mode} Get & check params (specifying a type; Arc Functions bare module mode)`, t => {
+    t.plan(6)
+    ssm.getParametersByPath({ Path: `/ArcAppTesting/tables` }, function (err, result) {
+      if (err) t.fail(err)
+      else {
+        t.equal(result.Parameters.length, 4, 'Got back correct number of params')
+        check({ result, type: 'tables', items: tables, fallback: true, t })
+      }
+    })
+  })
+
+  t.test(`${mode} Get & check params (specifying an invalid or unknown service)`, t => {
     t.plan(1)
     ssm.getParametersByPath({ Path: `/${app}/idk` }, function (err, result) {
       if (err) t.fail(err)
       else t.deepEqual(result.Parameters, [], 'No parameters returned')
+    })
+  })
+
+  t.test(`${mode} Get & check params (specifying an invalid or unknown service; Arc Functions bare module mode)`, t => {
+    t.plan(1)
+    ssm.getParametersByPath({ Path: `/ArcAppTesting/idk` }, function (err, result) {
+      if (err) t.fail(err)
+      else t.deepEqual(result.Parameters, [], 'No parameters returned')
+    })
+  })
+
+  t.test(`${mode} Get & check params (specifying an invalid or unknown app)`, t => {
+    t.plan(1)
+    ssm.getParametersByPath({ Path: `/idk` }, function (err, result) {
+      if (err) t.fail(err)
+      else t.deepEqual(result.Parameters, [], 'No parameters returned')
+    })
+  })
+
+  t.test(`${mode} Get & check params (specifying an unknown app + known service)`, t => {
+    t.plan(1)
+    ssm.getParametersByPath({ Path: `/idk/tables` }, function (err, result) {
+      if (err) t.fail(err)
+      else t.deepEqual(result.Parameters, [], 'No parameters returned')
+    })
+  })
+
+  /**
+   * ssm.getParameter()
+   */
+  t.test(`${mode} Get & check a param`, t => {
+    t.plan(1)
+    let key = `/${app}/tables/accounts`
+    ssm.getParameter({ Name: key }, function (err, result) {
+      if (err) t.fail(err)
+      else {
+        let { Name, Value } = result.Parameter
+        if (Name === key && Value === `mockapp-staging-accounts`) {
+          t.pass(`Found param: ${key}`)
+        }
+        else t.fail(`Could not find param: ${key}`)
+      }
+    })
+  })
+
+  t.test(`${mode} Get & check a param (Arc Functions bare module mode)`, t => {
+    t.plan(1)
+    let key = `/ArcAppTesting/tables/accounts`
+    ssm.getParameter({ Name: key }, function (err, result) {
+      if (err) t.fail(err)
+      else {
+        let { Name, Value } = result.Parameter
+        if (Name === key && Value === `mockapp-staging-accounts`) {
+          t.pass(`Found param: ${key}`)
+        }
+        else t.fail(`Could not find param: ${key}`)
+      }
+    })
+  })
+
+  t.test(`${mode} Getting a param without specifying a service type should fail`, t => {
+    t.plan(2)
+    let key = `/${app}`
+    ssm.getParameter({ Name: key }, function (err) {
+      if (!err) t.fail('Expected error')
+      else {
+        t.match(err.name, /ParameterNotFound/, 'Got ParameterNotFound error')
+        t.equal(err.message, null, 'Returned null value')
+      }
+    })
+  })
+
+  t.test(`${mode} Getting a param without specifying a param should fail`, t => {
+    t.plan(2)
+    let key = `/${app}/tables/idk`
+    ssm.getParameter({ Name: key }, function (err) {
+      if (!err) t.fail('Expected error')
+      else {
+        t.match(err.name, /ParameterNotFound/, 'Got ParameterNotFound error')
+        t.equal(err.message, null, 'Returned null value')
+      }
+    })
+  })
+
+  t.test(`${mode} Getting a param without specifying a param should fail (trailing slash)`, t => {
+    t.plan(2)
+    let key = `/${app}/tables/`
+    ssm.getParameter({ Name: key }, function (err) {
+      if (!err) t.fail('Expected error')
+      else {
+        t.match(err.name, /ValidationException/, 'Got ValidationException error')
+        t.match(err.message, /Parameter cannot end in \'\/\'/, 'Errored on trailing slash')
+      }
+    })
+  })
+
+  /**
+   * Fail on unsupported ssm methods
+   */
+  t.test(`${mode} Get & check params (without specifying a type)`, t => {
+    t.plan(2)
+    ssm.getParameters({ Names: [ 'a', 'b' ] }, function (err) {
+      if (!err) t.fail('Expected error')
+      else {
+        t.match(err.name, /InternalServerError/, 'Got InternalServerError error')
+        t.match(err.message, /Unrecognized request, Sandbox only supports/, 'Tried to provide a helpful error')
+      }
     })
   })
 
@@ -81,13 +221,13 @@ function runTests (runType, t) {
   t.test(`${mode} Get & check params provided by plugin (without specifying a type)`, t => {
     t.plan(5)
     // Should get all tables params back
-    ssm.getParametersByPath({ Path: '/plugins-sandbox' }, function (err, result) {
+    ssm.getParametersByPath({ Path: '/PluginsSandboxTesting' }, function (err, result) {
       if (err) t.fail(err)
       else {
         t.equal(result.Parameters.length, 2, 'One parameter returned')
-        t.equal(result.Parameters[0].Name, '/plugins-sandbox/ARC_SANDBOX/ports', 'Plugin parameter name correct')
+        t.equal(result.Parameters[0].Name, '/PluginsSandboxTesting/ARC_SANDBOX/ports', 'Plugin parameter name correct')
         t.match(result.Parameters[0].Value, /\"_arc\":/, 'Plugin parameter value correct')
-        t.equal(result.Parameters[1].Name, '/plugins-sandbox/myplugin/varOne', 'Plugin parameter name correct')
+        t.equal(result.Parameters[1].Name, '/PluginsSandboxTesting/myplugin/varOne', 'Plugin parameter name correct')
         t.equal(result.Parameters[1].Value, 'valueOne', 'Plugin parameter value correct')
       }
     })

--- a/test/unit/src/arc/_ssm/index-test.js
+++ b/test/unit/src/arc/_ssm/index-test.js
@@ -1,13 +1,17 @@
 let test = require('tape')
+let { updater } = require('@architect/utils')
 let { EventEmitter } = require('events')
 let ssm = require('../../../../../src/arc/_ssm')
 let req
 let res
 let resBody
+let update = updater('Sandbox tests ')
+let params = { inventory: { inv: { app: 'my-app' } }, update }
 function reset (t) {
   resBody = null
   req = new EventEmitter()
   req.method = 'POST'
+  req.headers = { 'x-amz-target': 'AmazonSSM.GetParametersByPath' }
   res = {
     end: (body) => {
       resBody = body
@@ -17,10 +21,15 @@ function reset (t) {
   }
 }
 
+test('Set up env', t => {
+  process.env.ARC_ENV = 'testing'
+  t.end()
+})
+
 test('ssm module should return 400 if request body is not JSON', t => {
   t.plan(2)
   reset(t)
-  ssm({ body: '{not-json' }, req, res)
+  ssm({ body: '{not-json' }, params, req, res)
   t.equals(res.statusCode, 400, 'response statusCode not set to 400')
 })
 
@@ -28,30 +37,35 @@ test('ssm module should return JSON containing all parameters for a stack if onl
   t.plan(4)
   reset(t)
   ssm({
-    body: '{"Path":"/myAppStaging"}',
+    body: '{"Path":"/MyAppTesting"}',
     services: {
       tables: { 'my-table': 'my-app-staging-my-table' },
       someplugin: { pluginService: 'some:other:arn' }
     }
-  }, req, res)
+  }, params, req, res)
   t.equals(res.statusCode, 200, 'response statuscode set to 200')
   let body = JSON.parse(resBody)
-  t.equals(body.Parameters.find(p => p.Name === '/myAppStaging/tables/my-table').Value, 'my-app-staging-my-table', 'returned an events Parameter with expected name and value')
-  t.equals(body.Parameters.find(p => p.Name === '/myAppStaging/someplugin/pluginService').Value, 'some:other:arn', 'returned a plugin Parameter with expected name and value')
+  t.equals(body.Parameters.find(p => p.Name === '/MyAppTesting/tables/my-table').Value, 'my-app-staging-my-table', 'returned an events Parameter with expected name and value')
+  t.equals(body.Parameters.find(p => p.Name === '/MyAppTesting/someplugin/pluginService').Value, 'some:other:arn', 'returned a plugin Parameter with expected name and value')
 })
 
 test('ssm module should return JSON containing all service type-specific parameters for a stack if both stack and service are specified', t => {
   t.plan(4)
   reset(t)
   ssm({
-    body: '{"Path":"/myAppStaging/someplugin"}',
+    body: '{"Path":"/MyAppTesting/someplugin"}',
     services: {
       tables: { 'my-table': 'my-app-staging-my-table' },
       someplugin: { pluginService: 'some:other:arn' }
     }
-  }, req, res)
+  }, params, req, res)
   t.equals(res.statusCode, 200, 'response statuscode set to 200')
   let body = JSON.parse(resBody)
-  t.notOk(body.Parameters.find(p => p.Name === '/myAppStaging/tables/my-table'), 'returned zero Parameters for service type not requested')
-  t.equals(body.Parameters.find(p => p.Name === '/myAppStaging/someplugin/pluginService').Value, 'some:other:arn', 'returned a plugin Parameter with expected name and value')
+  t.notOk(body.Parameters.find(p => p.Name === '/MyAppTesting/tables/my-table'), 'returned zero Parameters for service type not requested')
+  t.equals(body.Parameters.find(p => p.Name === '/MyAppTesting/someplugin/pluginService').Value, 'some:other:arn', 'returned a plugin Parameter with expected name and value')
+})
+
+test('Teardown', t => {
+  delete process.env.ARC_ENV
+  t.end()
 })

--- a/test/unit/src/arc/listener-test.js
+++ b/test/unit/src/arc/listener-test.js
@@ -3,7 +3,7 @@ let { EventEmitter } = require('events')
 let proxyquire = require('proxyquire')
 let params = null
 let listener = proxyquire('../../../../src/arc/_listener', {
-  './_ssm': (ps, req, res) => { params = ps; params.service = 'ssm'; res.end() },
+  './_ssm': (ps, p, req, res) => { params = ps; params.service = 'ssm'; res.end() },
   './_ws': (ps, req, res) => { params = ps; params.service = 'ws'; res.end() }
 })
 let req
@@ -19,7 +19,7 @@ test('_arc listener returns 404 for POST requests to bad urls', t => {
   reset(t)
   req.method = 'POST'
   req.url = '/something/else'
-  listener({}, req, res)
+  listener({}, {}, req, res)
   req.emit('end')
   t.equals(res.statusCode, 404, 'HTTP response status code set to 404')
 })
@@ -29,7 +29,7 @@ test('_arc listener passes request body to SSM service module for POST requests 
   reset(t)
   req.method = 'POST'
   req.url = '/_arc/ssm'
-  listener({}, req, res)
+  listener({}, {}, req, res)
   req.emit('data', { toString: () => 'somedata' })
   req.emit('end')
   t.equals(params.body, 'somedata', 'HTTP request body passed to ssm server module')
@@ -41,7 +41,7 @@ test('_arc listener passes request body to WS service module for POST requests t
   reset(t)
   req.method = 'POST'
   req.url = '/_arc/ws'
-  listener({}, req, res)
+  listener({}, {}, req, res)
   req.emit('data', { toString: () => 'somedata' })
   req.emit('end')
   t.equals(params.body, 'somedata', 'HTTP request body passed to ssm server module')


### PR DESCRIPTION
Harden SSM emulation
Fixed Sandbox responding to all SSM requests indiscriminately

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
