### PR TITLE
Fix/1319 error when no terminate on return

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 # Architect Sandbox changelog
 
 ---
+## [5.1.1] 2022-03-02
+### Fixed
+
+- Fixed sandbox not detecting lambda function return when process does not exit automatically
+  https://github.com/architect/architect/issues/1319
+
+---
 
 ## [5.1.0] 2022-02-28
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/sandbox",
-  "version": "5.1.0",
+  "version": "5.1.1-RC.0",
   "description": "Architect dev server: run full Architect projects locally & offline",
   "main": "src/index.js",
   "scripts": {

--- a/src/invoke-lambda/exec/spawn.js
+++ b/src/invoke-lambda/exec/spawn.js
@@ -231,7 +231,6 @@ module.exports = function spawnChild (params, callback) {
         process.stdout.write(out[0])
       }
       midArcOutput = true
-      return
     }
     if (data.includes(arcEnd)) {
       midArcOutput = false

--- a/test/integration/lambda-termination-test.js
+++ b/test/integration/lambda-termination-test.js
@@ -139,6 +139,19 @@ function runTests (runType, t) {
     })
   })
 
+  t.test(`${mode} Should terminate after return when process does not auto exit`, t => {
+    t.plan(3)
+    setup(t)
+    arc.events.publish({
+      name: 'event-no-exit-after-return',
+      payload
+    },
+    function done (err) {
+      if (err) t.fail(err)
+      else check(t)
+    })
+  })
+
   t.test(`${mode} Respect timeout for sync functions and kill process + spawned children (inside a Lambda via Linux /proc)`, t => {
     let isLinux = process.platform === 'linux'
     if (isLinux) {

--- a/test/mock/lambda-termination/app.arc
+++ b/test/mock/lambda-termination/app.arc
@@ -8,3 +8,4 @@ event-timeout-async-child
 event-timeout-async-settimeout
 event-timeout-sync
 event-timeout-sync-child
+event-no-exit-after-return

--- a/test/mock/lambda-termination/src/events/event-no-exit-after-return/config.arc
+++ b/test/mock/lambda-termination/src/events/event-no-exit-after-return/config.arc
@@ -1,0 +1,2 @@
+@aws
+timeout 1

--- a/test/mock/lambda-termination/src/events/event-no-exit-after-return/index.js
+++ b/test/mock/lambda-termination/src/events/event-no-exit-after-return/index.js
@@ -1,0 +1,18 @@
+let { createWriteStream } = require('fs')
+
+exports.handler = async (event) => {
+  event = JSON.parse(event.Records[0].Sns.Message)
+  let pathToFile = event.path
+  let timeout = 500
+  console.log(`event-no-exit-after-return will write to ${pathToFile} in ${timeout}ms...`)
+  setTimeout(() => {
+    // this should never execute as sandbox should kill process after return
+    console.log(`event-no-exit-after-return ${pathToFile}`)
+    let writeStream = createWriteStream(pathToFile)
+    writeStream.write('hiya')
+    writeStream.end()
+    console.log(`event-no-exit-after-return ending now!`)
+  }, timeout);
+
+  return { statusCode: 200, body: "some payload" }
+}


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [x] Added and/or updated integration tests (if appropriate)
- [x] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [x] Summarized your changes in `changelog.md`
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!

**Fix for:** https://github.com/architect/architect/issues/1319

It's common practice to leave connections open in lambda so they can be reused in future invocations: https://redis.com/blog/connection-pools-for-serverless-functions-and-backend-services/#:~:text=pools%20can%20help.-,Serverless%20functions,-Serverless%20functions%20are

A node process will not automatically exit while there is an open redis connection (I presume because the event loop is never empty?)

However, when this process is run in AWS lambda, they are able to detect that the handler function has returned a result, and put the process to sleep.

When running the same code in the sandbox, if the `__ARC_META__` and `__ARC__` segments arrive in the same chunk, the `invoke-lambda/exec/spawn` script fails to detect the `__ARC__` segment, and therefore doesn't know that the handler has successfully returned a result. Instead it generates a false positive timeout error when the lambda time limit is reached.

https://github.com/architect/sandbox/blob/81b5c108ef237b14f4a9cd1ad82fba97431c9fe7/src/invoke-lambda/exec/spawn.js#L223-L247

Here is the output of the test failing **before** the fix was implemented (2765e4d26616ea0695ec360e238ef7d8816cbd21):
<img width="931" alt="Screenshot 2022-03-02 at 10 56 39" src="https://user-images.githubusercontent.com/44057041/156358457-852b0dff-9423-4257-af53-38b873ce36d7.png">
Unfortunately I wasn't able to devise a scenario that would 100% guarantee that both the `__ARC_META__` and `__ARC__` segments would be received in the same chunk, so this test is only detects the issue ~50% of the time.

After implementing the fix (bf90817e2619cbe010085d095466e9bb740d7a8d), I was able to run the test suite 100 times without a failure.