### PR TITLE
Sandbox services should only listen on localhost

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,15 @@
 
 ---
 
+## [5.2.4] unreleased
+
+### Fixed
+
+- Sandbox servers will now only listen to the loopback interface and will not
+  listen for inbound connections from the network.
+
+---
+
 ## [5.2.3] 2022-04-19
 
 ### Fixed

--- a/src/arc/index.js
+++ b/src/arc/index.js
@@ -21,7 +21,7 @@ function start (params, callback) {
       let listener = _listener.bind({}, services, params)
       _arcServices = http.createServer(listener)
       arc.livereload = _livereload(_arcServices, params)
-      _arcServices.listen(ports._arc, err => {
+      _arcServices.listen(ports._arc, 'localhost', err => {
         if (err) callback(err)
         else {
           if (!restart) update.done('Started AWS service emulator')

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -17,7 +17,7 @@ function start (params, callback) {
 
   let listener = _listener.bind({}, params)
   eventBus = http.createServer(listener)
-  eventBus.listen(ports.events, err => {
+  eventBus.listen(ports.events, 'localhost', err => {
     if (err) callback(err)
     else {
       update.done('@events and @queues ready on local event bus')

--- a/src/http/index.js
+++ b/src/http/index.js
@@ -70,7 +70,7 @@ function start (params, callback) {
       }
 
       let httpPort = params.ports.http
-      httpServer.listen(httpPort, callback)
+      httpServer.listen(httpPort, 'localhost', callback)
     }
   ], callback)
 }

--- a/src/sandbox/ports.js
+++ b/src/sandbox/ports.js
@@ -78,7 +78,7 @@ function checkPort (checking, ports, name, single, callback) {
       let msg = `Could not find open port after 50 tries, please close some applications and try again`
       return callback(Error(msg))
     }
-    tester.listen(checking)
+    tester.listen(checking, 'localhost')
     tester.once('error', err => {
       if (err.message.includes('EADDRINUSE')) {
         if (single) {

--- a/src/tables/index.js
+++ b/src/tables/index.js
@@ -25,7 +25,7 @@ function start (params, callback) {
   series([
     function (callback) {
       if (!hasExternalDb) {
-        dynamo = dynalite({ createTableMs: 0 }).listen(ports.tables, callback)
+        dynamo = dynalite({ createTableMs: 0 }).listen(ports.tables, 'localhost', callback)
       }
       else callback()
     },

--- a/test/integration/tables-test.js
+++ b/test/integration/tables-test.js
@@ -321,7 +321,7 @@ function runTests (runType, t) {
   t.test(`${mode} Start external DB`, t => {
     t.plan(1)
     dynaliteServer = dynalite({ path: join(mock, 'normal', '.db'), createTableMs: 0 })
-    dynaliteServer.listen(externalDBPort, err => {
+    dynaliteServer.listen(externalDBPort, 'localhost', err => {
       if (err) t.fail(err)
       else t.pass('External DB successfully started')
     })

--- a/test/unit/src/sandbox/ports-test.js
+++ b/test/unit/src/sandbox/ports-test.js
@@ -12,7 +12,7 @@ let inventory, params, tester
 async function listen (t, port) {
   return new Promise((res, rej) => {
     tester = net.createServer()
-    tester.listen(port)
+    tester.listen(port, 'localhost')
     tester.once('error', err => {
       t.fail(err)
       rej()

--- a/test/utils/_sidechannel.js
+++ b/test/utils/_sidechannel.js
@@ -21,7 +21,7 @@ let makeSideChannel = async (port = 3433) => {
     })
   })
 
-  await new Promise((resolve, reject) => activeSideChannel.listen(port, err => err ? reject(err) : resolve()))
+  await new Promise((resolve, reject) => activeSideChannel.listen(port, 'localhost', err => err ? reject(err) : resolve()))
   console.log('Started test side-channel')
 
   return {


### PR DESCRIPTION
A sandbox server should only listen on localhost, and should not listen for inbound connections from the Internet.

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [x] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
