### PR TITLE
Correctly reflect where the sandbox is listening

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [5.3.1] 2022-07-01
+
+### Changed
+
+- Updated `pretty-print` to show which host the sandbox is listening on
+
+---
+
 ## [5.3.0] 2022-06-29
 
 ### Changed

--- a/src/sandbox/print-status.js
+++ b/src/sandbox/print-status.js
@@ -8,7 +8,7 @@ let httpConfig = require('../http/_config')
  * Pretty print all the things
  */
 module.exports = function prettyPrint (params, start, callback) {
-  let { cwd, inventory, ports, restart, update } = params
+  let { cwd, host, inventory, ports, restart, update } = params
   let { http, ws } = inventory.inv
 
   if (restart) {
@@ -54,7 +54,7 @@ module.exports = function prettyPrint (params, start, callback) {
     }
 
     if (http || ws) {
-      let link = chalk.green.bold.underline(`http://localhost:${ports.http}\n`)
+      let link = chalk.green.bold.underline(`http://${host || 'localhost'}:${ports.http}\n`)
       update.raw(`\n    ${link}`)
     }
   }


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `main`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Summarized your changes in `changelog.md`
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!

---

Side effect of #678 

👋🏼 this is my first open source commit so please forgive me if I've done anything wrong above.  When I ran the tests locally, everything passed apart from a check of the version:
 
![image](https://user-images.githubusercontent.com/3603112/176887311-1e40a5ca-1378-4032-9a58-886695081a97.png)

I checked out the previous state of `main` and had the exact same output.

In terms of updating unit tests, I don't believe this change necessitates any updates.