### PR TITLE
Fix links to main branches

### DIFF
--- a/.github/code_of_conduct.md
+++ b/.github/code_of_conduct.md
@@ -2,7 +2,7 @@
 
 We are strongly committed to ensuring the Architect community, and the various online and offline spaces in which its members congregate and collaborate, are safe, positive, inclusive, constructive, and welcoming environments.
 
-As such, the Architect project adheres to the [OpenJS Foundation Code of Conduct](https://github.com/openjs-foundation/cross-project-council/blob/master/CODE_OF_CONDUCT.md), which itself adheres to the [Contributor Covenant](https://www.contributor-covenant.org).
+As such, the Architect project adheres to the [OpenJS Foundation Code of Conduct](https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md), which itself adheres to the [Contributor Covenant](https://www.contributor-covenant.org).
 
 Lack of familiarity with this or the OpenJS Foundation Codes of Conduct, or the Contributor covenant, is not an excuse for non-adherence.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:
 
-- [ ] Forked the repo and created your branch from `master`
+- [ ] Forked the repo and created your branch from `main`
 - [ ] Made sure tests pass (run `npm it` from the repo root)
 - [ ] Expanded test coverage related to your changes:
   - [ ] Added and/or updated unit tests (if appropriate)


### PR DESCRIPTION
This fixes links now pointing to `main` branches in the `code_of_conduct.md` and `pull_request_template.md` files.

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [x] Added and/or updated unit tests (if appropriate)
  - [x] Added and/or updated integration tests (if appropriate)
- [x] Updated relevant documentation:
  - [x] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [x] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [x] Summarized your changes in `changelog.md`
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!

---

I did not update the `changelog.md` file, as it seemed [markdown fixes may not need this](https://github.com/architect/sandbox/commit/6ce2c4086b6df3d24738cb6f0c94f8558f225c14).