### PR TITLE
address high severity vulns: new aws-sdk + tap-arc

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "src/index.js",
   "scripts": {
     "test": "npm run lint && npm run test:integration && npm run coverage",
-    "test:unit": "cross-env tape 'test/unit/**/*-test.js' | tap-spec",
-    "test:integration": "cross-env tape 'test/integration/**/*-test.js' | tap-spec",
+    "test:unit": "cross-env tape 'test/unit/**/*-test.js' | tap-arc",
+    "test:integration": "cross-env tape 'test/integration/**/*-test.js' | tap-arc",
     "coverage": "nyc --reporter=lcov --reporter=text npm run test:unit",
     "lint": "eslint . --fix",
     "rc": "npm version prerelease --preid RC",
@@ -41,7 +41,7 @@
     "@aws-sdk/client-ssm": "3.188.0",
     "@aws-sdk/lib-dynamodb": "3.188.0",
     "@begin/hashid": "~1.0.0",
-    "aws-sdk": "2.1055.0",
+    "aws-sdk": "2.1363.0",
     "chalk": "4.1.2",
     "chokidar": "~3.5.3",
     "depstatus": "~1.1.1",
@@ -71,7 +71,7 @@
     "pkg": "~5.8.1",
     "proxyquire": "~2.1.3",
     "sinon": "~15.0.3",
-    "tap-spec": "~5.0.0",
+    "tap-arc": "~0.3.5",
     "tape": "~5.6.3",
     "tiny-json-http": "~7.5.1"
   },


### PR DESCRIPTION
I ack `tap-arc` isn't perfect, but it does drop in and fixes 8 vulnerabilities reported by npm audit