### PR TITLE
Fix string coercion of certain unicode data in large Lambda response payloads

### DIFF
--- a/src/arc/_listener.js
+++ b/src/arc/_listener.js
@@ -3,12 +3,12 @@ let _ws = require('./_ws')
 let { runtimeAPI }  = require('./_runtime-api')
 
 module.exports = function _arcListener (services, params, req, res) {
-  let body = []
+  let raw = []
 
-  req.on('data', chunk => body.push(chunk))
+  req.on('data', chunk => raw.push(chunk))
 
   req.on('end', () => {
-    body = body.toString()
+    let body = Buffer.concat(raw).toString()
 
     // Parameter store
     if (req.url.startsWith('/_arc/ssm')) {

--- a/src/invoke-lambda/exec/runtimes/node.js
+++ b/src/invoke-lambda/exec/runtimes/node.js
@@ -6,7 +6,7 @@ let url = p => runtimeAPI + '/2018-06-01/runtime/' + p;
 let http = require('http');
 let get = client.bind({}, 'GET');
 let post = client.bind({}, 'POST');
-let jsonType = 'application/json';
+let jsonType = 'application/json; charset=utf-8';
 function client (method, params) {
   return new Promise((resolve, reject) => {
     let headers = method === 'GET'

--- a/test/integration/http/misc-http-test.js
+++ b/test/integration/http/misc-http-test.js
@@ -136,8 +136,9 @@ function runTests (runType, t) {
     }, function _got (err, result) {
       if (err) t.end(err)
       else {
-        let big = 1000 * 900 * 6
-        t.ok(Buffer.byteLength(result.body) > big, 'Did not fail on a very large response')
+        // Sizes are a bit less predictable when generating random unicode, so we'll be a bit conservative with the estimations and see if anything breaks
+        let big = 1000 * 750 * 6
+        t.ok(Buffer.byteLength(JSON.stringify(result.body)) > big, 'Did not fail on a very large response')
       }
     })
   })

--- a/test/mock/normal/src/http/get-big/index.js
+++ b/test/mock/normal/src/http/get-big/index.js
@@ -1,5 +1,5 @@
 exports.handler = async (event) => {
-  let validSize = (1000 * 999 * 6)
+  let validSize = (1000 * 999 * 6) + 1
   return {
     statusCode: 200,
     headers: { 'content-type': 'text/html' },

--- a/test/mock/normal/src/http/get-big_unicode/index.js
+++ b/test/mock/normal/src/http/get-big_unicode/index.js
@@ -1,8 +1,14 @@
 exports.handler = async (event) => {
-  let validSize = (1000 * 499 * 6)
+  let rando = {}
+  let loops = 4000
+  let arr = new Array(1000)
+  for (let i = 0; i < loops; i++) {
+    rando[i] = Array.from(arr, () => String.fromCharCode(0x0020 + Math.random() * 0x007F))
+      .join('')
+  }
   return {
     statusCode: 200,
-    headers: { 'content-type': 'text/html' },
-    body: 'ü'.repeat(validSize)
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+    body: JSON.stringify(rando),
   }
 }

--- a/test/unit/src/arc/listener-test.js
+++ b/test/unit/src/arc/listener-test.js
@@ -30,7 +30,7 @@ test('_arc listener passes request body to SSM service module for POST requests 
   req.method = 'POST'
   req.url = '/_arc/ssm'
   listener({}, {}, req, res)
-  req.emit('data', { toString: () => 'somedata' })
+  req.emit('data', Buffer.from('somedata'))
   req.emit('end')
   t.equals(params.body, 'somedata', 'HTTP request body passed to ssm server module')
   t.equals(params.service, 'ssm', 'HTTP request body passed to ssm server module')
@@ -42,7 +42,7 @@ test('_arc listener passes request body to WS service module for POST requests t
   req.method = 'POST'
   req.url = '/_arc/ws'
   listener({}, {}, req, res)
-  req.emit('data', { toString: () => 'somedata' })
+  req.emit('data', Buffer.from('somedata'))
   req.emit('end')
   t.equals(params.body, 'somedata', 'HTTP request body passed to ssm server module')
   t.equals(params.service, 'ws', 'HTTP request body passed to ssm server module')


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `main`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
