### PR TITLE
Add `getRemainingTimeInMillis()` method to Node.js Lambda context; fixes #1427

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,19 @@
 
 ---
 
+## [5.6.8] 2023-05-11
+
+### Added
+
+- Add `getRemainingTimeInMillis()` method to Node.js Lambda context; fixes #1427
+
+
+### Changed
+
+- Updated dependencies
+
+---
+
 ## [5.6.7] 2023-05-01
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@architect/eslint-config": "~2.1.1",
-    "@architect/functions": "~5.4.0",
+    "@architect/functions": "~6.0.0",
     "@architect/req-res-fixtures": "git+https://github.com/architect/req-res-fixtures.git",
     "cross-env": "~7.0.3",
     "eslint": "~8.39.0",

--- a/src/invoke-lambda/env/context.js
+++ b/src/invoke-lambda/env/context.js
@@ -19,7 +19,6 @@ module.exports = function createLambdaContext (params) {
       functionName,
       functionVersion,
       invokedFunctionArn: 'sandbox',
-      // TODO: getRemainingTimeInMillis()
     }
     if (apiType?.startsWith('http')) lambdaContext.memoryLimitInMB = memory
     else lambdaContext.mem = memory
@@ -33,7 +32,7 @@ module.exports = function createLambdaContext (params) {
       invoked_function_arn: invokedFunctionArn,
       memory_limit_in_mb: memory,
     }
-    // TODO: get_remaining_time_in_millis()
+    // TODO: get_remaining_time_in_millis() for py + rb
     // TODO Ruby only: deadline_ms
     return lambdaContext
   }

--- a/src/invoke-lambda/exec/runtimes/node-esm.mjs
+++ b/src/invoke-lambda/exec/runtimes/node-esm.mjs
@@ -64,6 +64,7 @@ function client (method, params) {
       let { headers, body: event } = invocation;
 
       let requestID = headers['Lambda-Runtime-Aws-Request-Id'] || headers['lambda-runtime-aws-request-id'];
+      let deadlineMS = headers['Lambda-Runtime-Deadline-Ms'] || headers['lambda-runtime-deadline-ms'];
       let errorEndpoint = url('invocation/' + requestID + '/error');
       let responseEndpoint = url('invocation/' + requestID + '/response');
 
@@ -85,6 +86,8 @@ function client (method, params) {
         }
       }
       try {
+        function getRemainingTimeInMillis () { return deadlineMS - Date.now(); }
+        context.getRemainingTimeInMillis = getRemainingTimeInMillis;
         const response = handler(event, context, callback);
         if (isPromise(response)) {
           response.then(result => callback(null, result)).catch(callback);

--- a/test/integration/http/misc-http-test.js
+++ b/test/integration/http/misc-http-test.js
@@ -116,6 +116,34 @@ function runTests (runType, t) {
     })
   })
 
+  t.test(`[context.getRemainingTimeInMillis() / ${runType}] get /context-remaining-ms-node-cjs`, t => {
+    t.plan(1)
+    tiny.get({
+      url: url + '/context-remaining-ms-node-cjs'
+    }, function _got (err, result) {
+      if (err) t.end(err)
+      else {
+        let { remaining } = result.body
+        // Would you believe that Windows, being Windows, actually sometimes calculates >5s remaining on a 5s timeout? You can't make this stuff up.
+        t.ok(remaining > 0 && remaining < 6000, `Got remaining time in milliseconds from context method: ${remaining}`)
+      }
+    })
+  })
+
+  t.test(`[context.getRemainingTimeInMillis() / ${runType}] get /context-remaining-ms-node-esm`, t => {
+    t.plan(1)
+    tiny.get({
+      url: url + '/context-remaining-ms-node-esm'
+    }, function _got (err, result) {
+      if (err) t.end(err)
+      else {
+        let { remaining } = result.body
+        // Would you believe that Windows, being Windows, actually sometimes calculates >5s remaining on a 5s timeout? You can't make this stuff up.
+        t.ok(remaining > 0 && remaining < 6000, `Got remaining time in milliseconds from context method: ${remaining}`)
+      }
+    })
+  })
+
   t.test(`[Big, but not oversized response / ${runType}] get /big`, t => {
     t.plan(1)
     tiny.get({

--- a/test/integration/misc-test.js
+++ b/test/integration/misc-test.js
@@ -10,7 +10,7 @@ test('Set up env', t => {
   t.ok(sandbox, 'Got Sandbox')
 })
 
-test('Run misc HTTP tests', t => {
+test('Run misc handler tests', t => {
   run(runTests, t)
   t.end()
 })

--- a/test/mock/normal/app.arc
+++ b/test/mock/normal/app.arc
@@ -33,6 +33,8 @@ get     /promise-return
 get     /reject-promise
 get     /throw-sync-error
 get     /times-out
+get     /context-remaining-ms-node-cjs
+get     /context-remaining-ms-node-esm
 get     /python-error
 get     /ruby-error
 /custom

--- a/test/mock/normal/src/http/get-context_remaining_ms_node_cjs/index.js
+++ b/test/mock/normal/src/http/get-context_remaining_ms_node_cjs/index.js
@@ -1,0 +1,7 @@
+exports.handler = async (event, context) => {
+  return {
+    statusCode: 200,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ remaining: context.getRemainingTimeInMillis() })
+  }
+}

--- a/test/mock/normal/src/http/get-context_remaining_ms_node_esm/index.mjs
+++ b/test/mock/normal/src/http/get-context_remaining_ms_node_esm/index.mjs
@@ -1,0 +1,7 @@
+export async function handler (event, context) {
+  return {
+    statusCode: 200,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ remaining: context.getRemainingTimeInMillis() })
+  }
+}


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `main`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
