### PR TITLE
Coerce type in `getRemainingTimeInMillis` Lambda context method

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [unreleased] 2023-05-12
+
+### Fixed
+
+- Coerce type in `getRemainingTimeInMillis` Lambda context method
+
+---
+
 ## [5.6.8] 2023-05-11
 
 ### Added

--- a/src/invoke-lambda/exec/runtimes/node-esm.mjs
+++ b/src/invoke-lambda/exec/runtimes/node-esm.mjs
@@ -86,7 +86,7 @@ function client (method, params) {
         }
       }
       try {
-        function getRemainingTimeInMillis () { return deadlineMS - Date.now(); }
+        function getRemainingTimeInMillis () { return Number(deadlineMS) - Date.now(); }
         context.getRemainingTimeInMillis = getRemainingTimeInMillis;
         const response = handler(event, context, callback);
         if (isPromise(response)) {

--- a/src/invoke-lambda/exec/runtimes/node.js
+++ b/src/invoke-lambda/exec/runtimes/node.js
@@ -169,7 +169,7 @@ function client (method, params) {
         }
       }
       try {
-        function getRemainingTimeInMillis () { return deadlineMS - Date.now(); }
+        function getRemainingTimeInMillis () { return Number(deadlineMS) - Date.now(); }
         context.getRemainingTimeInMillis = getRemainingTimeInMillis;
         const response = handler(event, context, callback);
         if (isPromise(response)) {

--- a/test/integration/http/misc-http-test.js
+++ b/test/integration/http/misc-http-test.js
@@ -125,7 +125,7 @@ function runTests (runType, t) {
       else {
         let { remaining } = result.body
         // Would you believe that Windows, being Windows, actually sometimes calculates >5s remaining on a 5s timeout? You can't make this stuff up.
-        t.ok(remaining > 0 && remaining < 6000, `Got remaining time in milliseconds from context method: ${remaining}`)
+        t.ok(remaining > 0 && remaining <= 5000, `Got remaining time in milliseconds from context method: ${remaining}`)
       }
     })
   })
@@ -139,7 +139,7 @@ function runTests (runType, t) {
       else {
         let { remaining } = result.body
         // Would you believe that Windows, being Windows, actually sometimes calculates >5s remaining on a 5s timeout? You can't make this stuff up.
-        t.ok(remaining > 0 && remaining < 6000, `Got remaining time in milliseconds from context method: ${remaining}`)
+        t.ok(remaining > 0 && remaining <= 5000, `Got remaining time in milliseconds from context method: ${remaining}`)
       }
     })
   })


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `main`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
