### PR TITLE
add aws-sdk/node-http-handler

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,15 @@
 
 ---
 
+## [5.7.2] 2023-07-05
+
+### Fixed
+
+- Added `@aws-sdk/node-http-helper` which is required by `@architect/functions` when interacting with DynamoDB from a Node 18 process.
+  - `node-http-helper` was likely available further down the dependency graph but has been removed at some point.
+
+---
+
 ## [5.7.0 - 5.7.1] 2023-06-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@aws-sdk/client-sqs": "^3.316.0",
     "@aws-sdk/client-ssm": "^3.316.0",
     "@aws-sdk/lib-dynamodb": "^3.316.0",
+    "@aws-sdk/node-http-handler": "^3.360.0",
     "@begin/hashid": "~1.0.0",
     "aws-sdk": "^2.1363.0",
     "chalk": "4.1.2",


### PR DESCRIPTION
> - Added `@aws-sdk/node-http-helper` which is required by `@architect/functions` when interacting with DynamoDB from a Node 18 process.
>   - `node-http-helper` was likely available further down the dependency graph but has been removed at some point.

For reference, this is the code path I'm running into in Sandbox + Node18 + Dynamo interaction
https://github.com/architect/functions/commit/f80010f2d7619f1ce34d9d6770e64e6f1122ebdc

---

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `main`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
