### PR TITLE
help user when the port is in use

### DIFF
--- a/src/sandbox/ports.js
+++ b/src/sandbox/ports.js
@@ -82,7 +82,7 @@ function checkPort (checking, ports, name, single, callback) {
     tester.once('error', err => {
       if (err.message.includes('EADDRINUSE')) {
         if (single) {
-          return callback(Error(`Port ${checking} (${name}) is already in use, please select another with prefs.arc`))
+          return callback(Error(`Port ${checking} (${name}) is already in use, please select another with prefs.arc\nSee https://arc.codes/docs/en/reference/configuration/local-preferences#ports---list for config`))
         }
         else {
           tries++


### PR DESCRIPTION
I ran `enhance dev` and because I was already running the server, it dumped an error.

But "please select another with prefs.arc" didn't help because I didn't know how and `perfs.arc` doesn't appear anywhere in the enhance docs (I could work out that it was architect that was the source).

So this is one step in making the UX a little better.

I suspect a nice short URL (one that can be maintained if needed) might be better, but again, a start.

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `main`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [/] Added and/or updated unit tests (if appropriate)
  - [/] Added and/or updated integration tests (if appropriate)
- [/] Updated relevant documentation:
  - [/] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [/] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md` - want to check this is okay before making further changes
- [/] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

