### PR TITLE
Work around qemu/emulator port conflicts by using `net.createConnection` instead of `net.createServer`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,11 +2,16 @@
 
 ---
 
-## [5.8.4] 2023-10-23
+## [5.8.4 - 5.8.5] 2023-10-23
 
 ### Added
 
 - Added support for hydration of platform-specific binary deps (namely: Python); fixes #1457
+
+
+### Fixed
+
+- Fixed issue where qemu/emulator port conflicts were not detected with our open port tester; fixes 1441
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "src/index.js",
   "scripts": {
     "test": "npm run lint && npm run test:integration && npm run coverage",
-    "test:unit": "cross-env tape 'test/unit/**/*-test.js' | tap-spec",
-    "test:integration": "cross-env tape 'test/integration/**/*-test.js' | tap-spec",
+    "test:unit": "cross-env tape 'test/unit/**/*-test.js' | tap-arc",
+    "test:integration": "cross-env tape 'test/integration/**/*-test.js' | tap-arc",
     "coverage": "nyc --reporter=lcov --reporter=text npm run test:unit",
     "lint": "eslint . --fix",
     "rc": "npm version prerelease --preid RC",
@@ -72,7 +72,7 @@
     "nyc": "~15.1.0",
     "pkg": "~5.8.1",
     "proxyquire": "~2.1.3",
-    "tap-spec": "~5.0.0",
+    "tap-arc": "~1.1.0",
     "tape": "~5.7.2",
     "tiny-json-http": "~7.5.1"
   },


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `main`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
