### PR TITLE
Ensure X-Forwarded-Port header is a string

### DIFF
--- a/src/http/invoke-http/http/_req-header-fmt.js
+++ b/src/http/invoke-http/http/_req-header-fmt.js
@@ -48,7 +48,7 @@ module.exports = function requestHeaderFormatter (reqHeaders = {}, params) {
     headers['x-forwarded-for'] = ip
   }
   if (!headers['x-forwarded-port'] && req.socket?.localPort) {
-    headers['x-forwarded-port'] = req.socket.localPort
+    headers['x-forwarded-port'] = req.socket.localPort.toString()
   }
   if (!headers['x-forwarded-proto']) {
     headers['x-forwarded-proto'] = 'http'

--- a/src/http/invoke-http/rest/_req-header-fmt.js
+++ b/src/http/invoke-http/rest/_req-header-fmt.js
@@ -61,7 +61,7 @@ module.exports = function requestHeaderFormatter (reqHeaders = {}, httpApi, para
     headers['X-Forwarded-For'] = ip
   }
   if (!headers['X-Forwarded-Port'] && req.socket?.localPort) {
-    headers['X-Forwarded-Port'] = req.socket.localPort
+    headers['X-Forwarded-Port'] = req.socket.localPort.toString()
   }
   if (!headers['X-Forwarded-Proto']) {
     headers['X-Forwarded-Proto'] = 'http'

--- a/src/http/invoke-ws/_req-fmt.js
+++ b/src/http/invoke-ws/_req-fmt.js
@@ -62,7 +62,7 @@ module.exports = function requestFormatter (params) {
       request.headers['X-Forwarded-For'] = sourceIp
     }
     if (!request.headers['X-Forwarded-Port'] && req?.socket?.localPort) {
-      request.headers['X-Forwarded-Port'] = req.socket.localPort
+      request.headers['X-Forwarded-Port'] = req.socket.localPort.toString()
     }
     if (!request.headers['X-Forwarded-Proto']) {
       request.headers['X-Forwarded-Proto'] = 'http'

--- a/test/unit/src/http/invoke-http/http/_req-header-fmt-test.js
+++ b/test/unit/src/http/invoke-http/http/_req-header-fmt-test.js
@@ -3,7 +3,7 @@ let { join } = require('path')
 let sut = join(process.cwd(), 'src', 'http', 'invoke-http', 'http', '_req-header-fmt')
 let requestHeaderFormatter = require(sut)
 let params = {
-  req: { socket: { localPort: 'foo' } },
+  req: { socket: { localPort: 1234 } },
   ip: 'bar',
 }
 
@@ -40,7 +40,7 @@ test('Header mangling & cookies (HTTP)', t => {
   t.equal(cookies[1], 'fiz=buz', 'Got back cookie two')
   // Metadata
   t.equal(headers['x-forwarded-for'], 'bar', 'Got back header: x-forwarded-for')
-  t.equal(headers['x-forwarded-port'], 'foo', 'Got back header: x-forwarded-port')
+  t.equal(headers['x-forwarded-port'], '1234', 'Got back header: x-forwarded-port')
   t.equal(headers['x-forwarded-proto'], 'http', 'Got back header: x-forwarded-proto')
 })
 

--- a/test/unit/src/http/invoke-http/rest/_req-header-fmt-test.js
+++ b/test/unit/src/http/invoke-http/rest/_req-header-fmt-test.js
@@ -3,7 +3,7 @@ let { join } = require('path')
 let sut = join(process.cwd(), 'src', 'http', 'invoke-http', 'rest', '_req-header-fmt')
 let headerFormatter = require(sut)
 let params = {
-  req: { socket: { localPort: 'foo' } },
+  req: { socket: { localPort: 1234 } },
   ip: 'bar',
 }
 
@@ -37,7 +37,7 @@ test('Header mangling (HTTP + Lambda 1.0 payload)', t => {
   t.ok(headers.Host, 'Got back upcased Host')
   t.ok(headers['User-Agent'], 'Got back upcased User-Agent')
   t.ok(headers['X-Forwarded-For'], 'Got back upcased X-Forwarded-For')
-  t.ok(headers['X-Forwarded-Port'], 'Got back upcased X-Forwarded-Port')
+  t.equal(headers['X-Forwarded-Port'], '1234', 'Got back upcased X-Forwarded-Port')
   t.ok(headers['X-Forwarded-Proto'], 'Got back upcased X-Forwarded-Proto')
   t.ok(headers.date, 'Got back lowcased date')
   t.ok(headers.foo, 'Got back lowcased foo')
@@ -45,7 +45,7 @@ test('Header mangling (HTTP + Lambda 1.0 payload)', t => {
   t.ok(multiValueHeaders.Host, 'Got back upcased Host')
   t.ok(multiValueHeaders['User-Agent'], 'Got back upcased User-Agent')
   t.ok(multiValueHeaders['X-Forwarded-For'], 'Got back upcased X-Forwarded-For')
-  t.ok(multiValueHeaders['X-Forwarded-Port'], 'Got back upcased X-Forwarded-Port')
+  t.deepEqual(multiValueHeaders['X-Forwarded-Port'], [ '1234' ], 'Got back upcased X-Forwarded-Port')
   t.ok(multiValueHeaders['X-Forwarded-Proto'], 'Got back upcased X-Forwarded-Proto')
   t.ok(multiValueHeaders.date, 'Got back lowcased date')
   t.ok(multiValueHeaders.foo, 'Got back lowcased foo')
@@ -105,7 +105,7 @@ test('Header mangling (REST)', t => {
   t.ok(headers.Host, 'Got back upcased Host')
   t.ok(headers['User-Agent'], 'Got back upcased User-Agent')
   t.ok(headers['X-Forwarded-For'], 'Got back upcased X-Forwarded-For')
-  t.ok(headers['X-Forwarded-Port'], 'Got back upcased X-Forwarded-Port')
+  t.equal(headers['X-Forwarded-Port'], '1234', 'Got back upcased X-Forwarded-Port')
   t.ok(headers['X-Forwarded-Proto'], 'Got back upcased X-Forwarded-Proto')
   t.ok(headers.Date, 'Got back upased Date')
   t.ok(headers.foo, 'Got back lowcased foo')
@@ -113,7 +113,7 @@ test('Header mangling (REST)', t => {
   t.ok(multiValueHeaders.Host, 'Got back upcased Host')
   t.ok(multiValueHeaders['User-Agent'], 'Got back upcased User-Agent')
   t.ok(multiValueHeaders['X-Forwarded-For'], 'Got back upcased X-Forwarded-For')
-  t.ok(multiValueHeaders['X-Forwarded-Port'], 'Got back upcased X-Forwarded-Port')
+  t.deepEqual(multiValueHeaders['X-Forwarded-Port'], [ '1234' ], 'Got back upcased X-Forwarded-Port')
   t.ok(multiValueHeaders['X-Forwarded-Proto'], 'Got back upcased X-Forwarded-Proto')
   t.ok(multiValueHeaders.Date, 'Got back upased Date')
   t.ok(multiValueHeaders.foo, 'Got back lowcased foo')


### PR DESCRIPTION
Headers must be strings by definition. This fixes the following stack trace resulting from running a basic example of [Mangum](https://mangum.io/#example):

```
Traceback (most recent call last):
  File "<string>", line 31, in <module>
  File "/example/python/vendor/mangum/adapter.py", line 82, in __call__
    http_cycle = HTTPCycle(handler.scope, handler.body)
                           ^^^^^^^^^^^^^
  File "/example/python/vendor/mangum/handlers/api_gateway.py", line 189, in scope
    "headers": [[k.encode(), v.encode()] for k, v in headers.items()],
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/example/python/vendor/mangum/handlers/api_gateway.py", line 189, in <listcomp>
    "headers": [[k.encode(), v.encode()] for k, v in headers.items()],
                             ^^^^^^^^
AttributeError: 'int' object has no attribute 'encode'
```

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `main`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
