### PR TITLE
Attempt to terminate via `SIGINT` + `SIGTERM`; should fix (or at least improve) #1479

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,16 @@
 
 ---
 
+## [6.0.4] 2024-03-27
+
+### Fixed
+
+- Make a best effort attempt to terminate the process via `SIGINT` + `SIGTERM` termination signals; should fix (or at least improve) #1479
+  - Sandbox running via CLI will now forcefully terminate itself after 5 seconds if the termination routine has stalled out or takes too long
+  - Thanks @lpsinger + @courey!
+
+---
+
 ## [6.0.3] 2024-03-25
 
 ### Changed


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `main`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
