### PR TITLE
Adds a new hook called 'post-seed' to allow for more granular triggering of plugins

### DIFF
--- a/src/sandbox/index.js
+++ b/src/sandbox/index.js
@@ -108,7 +108,7 @@ function _start (params, callback) {
 
     // Run post-seed scripts
     function (callback) {
-      let options = { method: 'post-seed', name: 'post-seed' }
+      let options = { method: 'postSeed', name: 'postSeed' }
       plugins(params, options, callback)
     },
 

--- a/src/sandbox/index.js
+++ b/src/sandbox/index.js
@@ -106,6 +106,12 @@ function _start (params, callback) {
       seed(params, callback)
     },
 
+    // Run post-seed scripts
+    function (callback) {
+      let options = { method: 'post-seed', name: 'post-seed' }
+      plugins(params, options, callback)
+    },
+
     // Run startup scripts (if present)
     function (callback) {
       startupScripts(params, callback)


### PR DESCRIPTION
Hey, this is a pretty small addition, it would add a new hook called 'post-seed' to the sandbox hooks. This would be helpful in cases where there are actions that need to take place once the data is added. 

For example: 
I have a local dynamodb instance (Docker), and want to emulate the realistic behavior of my table-streams. 
I also want to re-initialize fresh data from my `sandbox-seed.json` file each time I restart my app locally.

If my table streams are initialized/setup before the table is seeded, it will trigger as many times as there is relevant data in my seed. 


## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `main`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
