### PR TITLE
Only use valid characters in dummy AWS access keys

### DIFF
--- a/src/sandbox/creds.js
+++ b/src/sandbox/creds.js
@@ -16,8 +16,8 @@ module.exports = function loadCreds (params, callback) {
     })
     .catch(() => {
       params.creds = {
-        accessKeyId: 'arc_dummy_access_key',
-        secretAccessKey: 'arc_dummy_secret_key',
+        accessKeyId: 'arcDummyAccessKey',
+        secretAccessKey: 'arcDummySecretKey',
       }
       callback()
     })

--- a/test/utils/_lib.js
+++ b/test/utils/_lib.js
@@ -9,8 +9,8 @@ let copy = thing => JSON.parse(JSON.stringify(thing))
 
 // Dummy AWS creds
 let credentials = {
-  accessKeyId: 'arc_dummy_access_key',
-  secretAccessKey: 'arc_dummy_secret_key',
+  accessKeyId: 'arcDummyAccessKey',
+  secretAccessKey: 'arcDummySecretKey',
 }
 
 let data = { hi: 'there' }


### PR DESCRIPTION
Only use letters and numbers in dummy AWS access keys. Access keys that contain underscores are invalid.

This is required for using Architect with DynamoDB Local.

See notes section of
https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.DownloadingAndRunning.html.

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `main`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
