### PR TITLE
Fix enabling external database from @sandbox pragma

### DIFF
--- a/src/sandbox/ports.js
+++ b/src/sandbox/ports.js
@@ -36,7 +36,7 @@ module.exports = function getPorts (params, callback) {
     },
     function (callback) {
       // TODO add support for prefs
-      if (prefs?.['external-db'] || ARC_DB_EXTERNAL) {
+      if (preferences?.sandbox?.['external-db'] || ARC_DB_EXTERNAL) {
         ports.tables = prefs?.tables || n(ARC_TABLES_PORT)
         if (ports.tables) callback()
         else callback(Error('Sandbox must be configured with a database port when relying on an external database'))

--- a/src/tables/index.js
+++ b/src/tables/index.js
@@ -20,7 +20,7 @@ function start (params, callback) {
     return callback()
   }
 
-  hasExternalDb = process.env.ARC_DB_EXTERNAL
+  hasExternalDb = inv._project.preferences?.sandbox?.['external-db'] || process.env.ARC_DB_EXTERNAL
 
   series([
     function (callback) {

--- a/test/unit/src/sandbox/ports-test.js
+++ b/test/unit/src/sandbox/ports-test.js
@@ -167,7 +167,7 @@ test('Events port selection', async t => {
 })
 
 test('Tables port selection', async t => {
-  t.plan(6)
+  t.plan(7)
   let tables = 5555
 
   reset()
@@ -189,6 +189,15 @@ test('Tables port selection', async t => {
   params = { inventory, update }
   await getPorts(params)
   t.deepEqual(params.ports, { tables: port, ...always }, 'Got back tables port from prefs.arc')
+
+  reset()
+  inventory.inv.tables = []
+  inventory.inv._project.preferences.sandbox = { 'external-db': true, ports: { tables: port } }
+  params = { inventory, update }
+  await listen(t, port)
+  await getPorts(params)
+  t.deepEqual(params.ports, { tables: port, ...always }, 'Got back occupied tables port for external DB')
+  await stopListening(t)
 
   let envVar = 2345
   process.env.ARC_DB_EXTERNAL = true


### PR DESCRIPTION
Accoring to the documentation (https://arc.codes/docs/en/reference/cli/sandbox#%40sandbox), the `@sandbox` pragma supports an `external-db` option to enable an external database instead of Dynalite. Look for this option on `preferences.sandbox['external-db']`, not `preferences.sandbox.ports['external-db']`.