### PR TITLE
Bumps tmp, ws, and nyc to resolve vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,10 +45,10 @@
     "router": "2.2.0",
     "send": "1.2.0",
     "server-destroy": "1.0.1",
-    "tmp": "0.2.4",
+    "tmp": "0.2.7",
     "tree-kill": "1.2.2",
     "update-notifier-cjs": "5.1.7",
-    "ws": "8.18.0"
+    "ws": "8.21.1"
   },
   "devDependencies": {
     "@architect/eslint-config": "~3.0.0",
@@ -60,7 +60,7 @@
     "deno": "~2.5.1",
     "eslint": "~9.36.0",
     "fs-extra": "~11.3.0",
-    "nyc": "~17.1.0",
+    "nyc": "~18.0.0",
     "proxyquire": "~2.1.3",
     "tap-arc": "~1.3.2",
     "tape": "~5.9.0",


### PR DESCRIPTION
Like it says on the tin: bumps tmp, ws, and nyc to resolve vulnerabilities. I'm seeing 7 tests fail locally, but they're the same 7 that fail on a fresh clone, so hoping to see these all green in CI 🙏🏻 

Failing tests, locally, for reference:
```log
Failed tests: There were 7 failures

    ✗ [112] ReferenceError: Profile not found: default
    ✗ [117] TypeError: Cannot read properties of undefined (reading 'GetConnection')
    ✗ [118] TypeError: Cannot read properties of undefined (reading 'PostToConnection')
    ✗ [119] TypeError: Cannot read properties of undefined (reading 'DeleteConnection')
    ✗ [120] plan != count
    ✗ [1476] File not created as event timed out and process was terminated appropriately
    ✗ [1485] File not created as event timed out and process was terminated appropriately
```